### PR TITLE
v0.4

### DIFF
--- a/appinit.cpp
+++ b/appinit.cpp
@@ -1,0 +1,60 @@
+﻿#include "appinit.h"
+#include "qmutex.h"
+#include "qapplication.h"
+#include "qevent.h"
+#include "qwidget.h"
+
+//鼠标事件
+
+AppInit *AppInit::self = 0;
+AppInit *AppInit::Instance()
+{
+    if (!self) {
+        QMutex mutex;
+        QMutexLocker locker(&mutex);
+        if (!self) {
+            self = new AppInit;
+        }
+    }
+
+    return self;
+}
+
+AppInit::AppInit(QObject *parent) : QObject(parent)
+{
+}
+
+bool AppInit::eventFilter(QObject *obj, QEvent *evt)
+{
+    QWidget *w = (QWidget *)obj;
+    if (!w->property("canMove").toBool()) {
+        return QObject::eventFilter(obj, evt);
+    }
+
+    static QPoint mousePoint;
+    static bool mousePressed = false;
+
+    QMouseEvent *event = static_cast<QMouseEvent *>(evt);
+    if (event->type() == QEvent::MouseButtonPress) {
+        if (event->button() == Qt::LeftButton) {
+            mousePressed = true;
+            mousePoint = event->globalPos() - w->pos();
+            return true;
+        }
+    } else if (event->type() == QEvent::MouseButtonRelease) {
+        mousePressed = false;
+        return true;
+    } else if (event->type() == QEvent::MouseMove) {
+        if (mousePressed && (event->buttons() && Qt::LeftButton)) {
+            w->move(event->globalPos() - mousePoint);
+            return true;
+        }
+    }
+
+    return QObject::eventFilter(obj, evt);
+}
+
+void AppInit::start()
+{
+    qApp->installEventFilter(this);
+}

--- a/appinit.h
+++ b/appinit.h
@@ -1,0 +1,26 @@
+﻿#ifndef APPINIT_H
+#define APPINIT_H
+
+#include <QObject>
+
+class AppInit : public QObject
+{
+    Q_OBJECT
+public:
+    static AppInit *Instance();
+    explicit AppInit(QObject *parent = 0);    
+
+    void start();
+
+protected:
+    bool eventFilter(QObject *obj, QEvent *evt);
+
+private:
+    static AppInit *self;
+
+signals:
+
+public slots:
+};
+
+#endif // APPINIT_H

--- a/connnection.h
+++ b/connnection.h
@@ -1,0 +1,33 @@
+#ifndef CONNNECTION_H
+#define CONNNECTION_H
+#include <QMessageBox>
+#include <QSqlDatabase>
+#include <QSqlQuery>
+#include <QDebug>
+
+static bool createConnection(){
+
+
+    //连接第一个数据库
+    //QMYSQL
+    QSqlDatabase db = QSqlDatabase::addDatabase("QMYSQL", "connection1");
+    db.setHostName("127.0.0.1");
+    db.setUserName("root");
+    db.setPassword("root");
+    db.setPort(8889);
+    //test_majiang.db
+    db.setDatabaseName("test_majiang");
+
+    if (!db.open()) {
+        //critical(QWidget *parent, const QString &title,
+        //const QString &text,
+        //QMessageBox::StandardButtons buttons = Ok,
+        //QMessageBox::StandardButton defaultButton = NoButton)
+           QMessageBox::critical(0, "Cannot open database",
+                                 "Unable to establish a database connection", QMessageBox::Cancel);
+           return false;
+       }
+
+    return true;
+}
+#endif // CONNNECTION_H

--- a/iconhelper.cpp
+++ b/iconhelper.cpp
@@ -1,0 +1,262 @@
+﻿#include "iconhelper.h"
+
+//样式设计
+
+IconHelper *IconHelper::self = 0;
+IconHelper *IconHelper::Instance()
+{
+    if (!self) {
+        //线程同步
+        QMutex mutex;
+        //只能够定义局部变量
+        //简化互斥量的锁定和解锁操作
+        /*在该局部变量被创建的时候上锁，
+         * 当所在函数运行完毕后该QMutexLocker局部变量在栈中销毁掉，
+         * 根据他自己的机制也就相对应的解锁了。
+        */
+        QMutexLocker locker(&mutex);
+        //上面等价于：
+        //mutex.lock();。。。 mutex.unlock();
+        if (!self) {
+            self = new IconHelper;
+        }
+    }
+
+    return self;
+}
+
+//qApp是一个全局的一个对象
+//接收生命周期事件
+//一些框架级别组件的初始化
+//设置字体
+IconHelper::IconHelper(QObject *) : QObject(qApp)
+{
+    int fontId = QFontDatabase::addApplicationFont(":/image/fontawesome-webfont.ttf");
+    QStringList fontName = QFontDatabase::applicationFontFamilies(fontId);
+
+    if (fontName.count() > 0) {
+        iconFont = QFont(fontName.at(0));
+    } else {
+        qDebug() << "load fontawesome-webfont.ttf error";
+    }
+}
+
+void IconHelper::setIcon(QLabel *lab, QChar c, quint32 size)
+{
+    iconFont.setPixelSize(size);
+    lab->setFont(iconFont);
+    lab->setText(c);
+}
+
+void IconHelper::setIcon(QAbstractButton *btn, QChar c, quint32 size)
+{
+    iconFont.setPixelSize(size);
+    btn->setFont(iconFont);
+    btn->setText(c);
+}
+
+QPixmap IconHelper::getPixmap(const QString &color, QChar c, quint32 size,
+                              quint32 pixWidth, quint32 pixHeight)
+{
+    QPixmap pix(pixWidth, pixHeight);
+    pix.fill(Qt::transparent);//透明
+    //调色板
+
+    QPainter painter;
+    painter.begin(&pix);
+    //消除圆形图片锯齿
+     // 第一个参数：绘图抗锯齿，第二个参数：绘制的字体抗锯齿
+    painter.setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing);
+       //绘制轮廓线
+    painter.setPen(QColor(color));
+        //填充
+    painter.setBrush(QColor(color));
+
+    iconFont.setPixelSize(size);
+    painter.setFont(iconFont);
+        //画字体
+    painter.drawText(pix.rect(), Qt::AlignCenter, c);
+    painter.end();
+
+    return pix;
+}
+
+QPixmap IconHelper::getPixmap(QToolButton *btn, bool normal)
+{
+    //QPixmap依赖于硬件，QImage不依赖于硬件。
+    //QPixmap主要是用于绘图，针对屏幕显示而最佳化设计，
+    //QImage主要是为图像I/O、图片访问和像素修改而设计的。
+    //一般图片大的情况下，用QImage进行加载，然后转乘QPixmap用户绘制
+    QPixmap pix;
+        //indexOf()：返回某个指定的字符串值在字符串中首次出现的位置
+    int index = btns.indexOf(btn);
+
+    if (index >= 0) {
+        if (normal) {//正常图片（被选中）
+            pix = pixNormal.at(index);
+        } else {//加深图片
+            pix = pixDark.at(index);
+        }
+    }
+
+    return pix;
+}
+
+void IconHelper::setStyle(QWidget *widget, const QString &type, int borderWidth, const QString &borderColor,
+                          const QString &normalBgColor, const QString &darkBgColor,
+                          const QString &normalTextColor, const QString &darkTextColor)
+{
+    QString strBorder;
+    if (type == "top") {
+        //上、右、下、左边框宽度，
+        //padding：代表自身边框到自身内部另一个容器边框之间的距离，属于容器内距离。
+        strBorder = QString("border-width:%1px 0px 0px 0px;padding:%1px %2px %2px %2px;")
+                .arg(borderWidth).arg(borderWidth * 2);
+    } else if (type == "right") {
+        strBorder = QString("border-width:0px %1px 0px 0px;padding:%2px %1px %2px %2px;")
+                .arg(borderWidth).arg(borderWidth * 2);
+    } else if (type == "bottom") {
+        strBorder = QString("border-width:0px 0px %1px 0px;padding:%2px %2px %1px %2px;")
+                .arg(borderWidth).arg(borderWidth * 2);
+    } else if (type == "left") {
+        strBorder = QString("border-width:0px 0px 0px %1px;padding:%2px %2px %2px %1px;")
+                .arg(borderWidth).arg(borderWidth * 2);
+    }
+
+    //如果图标是左侧显示则需要让没有选中的按钮左侧也有加深的边框,颜色为背景颜色
+    QStringList qss;
+    qss.append(QString("QWidget[flag=\"%1\"] QAbstractButton{border-style:none;border-radius:0px;padding:5px;color:%2;background:%3;}")
+               .arg(type).arg(normalTextColor).arg(normalBgColor));
+
+    qss.append(QString("QWidget[flag=\"%1\"] QAbstractButton:hover,"
+                       "QWidget[flag=\"%1\"] QAbstractButton:pressed,"
+                       "QWidget[flag=\"%1\"] QAbstractButton:checked{"
+                       "border-style:solid;%2border-color:%3;color:%4;background:%5;}")
+               .arg(type).arg(strBorder).arg(borderColor).arg(darkTextColor).arg(darkBgColor));
+
+    widget->setStyleSheet(qss.join(""));
+}
+
+void IconHelper::setStyle(QWidget *widget, QList<QToolButton *> btns, QList<int> pixChar,
+                          quint32 iconSize, quint32 iconWidth, quint32 iconHeight,
+                          const QString &type, int borderWidth, const QString &borderColor,
+                          const QString &normalBgColor, const QString &darkBgColor,
+                          const QString &normalTextColor, const QString &darkTextColor)
+{
+    int btnCount = btns.count();
+    int charCount = pixChar.count();
+    if (btnCount <= 0 || charCount <= 0 || btnCount != charCount) {
+        return;
+    }
+
+    QString strBorder;
+    if (type == "top") {
+        strBorder = QString("border-width:%1px 0px 0px 0px;padding:%1px %2px %2px %2px;")
+                .arg(borderWidth).arg(borderWidth * 2);
+    } else if (type == "right") {
+        strBorder = QString("border-width:0px %1px 0px 0px;padding:%2px %1px %2px %2px;")
+                .arg(borderWidth).arg(borderWidth * 2);
+    } else if (type == "bottom") {
+        strBorder = QString("border-width:0px 0px %1px 0px;padding:%2px %2px %1px %2px;")
+                .arg(borderWidth).arg(borderWidth * 2);
+    } else if (type == "left") {
+        strBorder = QString("border-width:0px 0px 0px %1px;padding:%2px %2px %2px %1px;")
+                .arg(borderWidth).arg(borderWidth * 2);
+    }
+
+    //如果图标是左侧显示则需要让没有选中的按钮左侧也有加深的边框,颜色为背景颜色
+    QStringList qss;
+    if (btns.at(0)->toolButtonStyle() == Qt::ToolButtonTextBesideIcon) {
+        qss.append(QString("QWidget[flag=\"%1\"] QAbstractButton{border-style:solid;border-radius:0px;%2border-color:%3;color:%4;background:%5;}")
+                   .arg(type).arg(strBorder).arg(normalBgColor).arg(normalTextColor).arg(normalBgColor));
+    } else {
+        qss.append(QString("QWidget[flag=\"%1\"] QAbstractButton{border-style:none;border-radius:0px;padding:5px;color:%2;background:%3;}")
+                   .arg(type).arg(normalTextColor).arg(normalBgColor));
+    }
+
+    qss.append(QString("QWidget[flag=\"%1\"] QAbstractButton:hover,"
+                       "QWidget[flag=\"%1\"] QAbstractButton:pressed,"
+                       "QWidget[flag=\"%1\"] QAbstractButton:checked{"
+                       "border-style:solid;%2border-color:%3;color:%4;background:%5;}")
+               .arg(type).arg(strBorder).arg(borderColor).arg(darkTextColor).arg(darkBgColor));
+
+    qss.append(QString("QWidget#%1{background:%2;}").arg(widget->objectName()).arg(normalBgColor));
+
+    qss.append(QString("QWidget>QToolButton{border-width:0px;}"));
+    qss.append(QString("QWidget>QToolButton{background-color:%1;color:%2;}")
+               .arg(normalBgColor).arg(normalTextColor));
+    qss.append(QString("QWidget>QToolButton:hover,QWidget>QToolButton:pressed,QWidget>QToolButton:checked{background-color:%1;color:%2;}")
+               .arg(darkBgColor).arg(darkTextColor));
+
+    widget->setStyleSheet(qss.join(""));
+
+    for (int i = 0; i < btnCount; i++) {
+        //存储对应按钮对象,方便鼠标移上去的时候切换图片
+        QPixmap pixNormal = getPixmap(normalTextColor, QChar(pixChar.at(i)), iconSize, iconWidth, iconHeight);
+        QPixmap pixDark = getPixmap(darkTextColor, QChar(pixChar.at(i)), iconSize, iconWidth, iconHeight);
+
+        btns.at(i)->setIcon(QIcon(pixNormal));
+        btns.at(i)->setIconSize(QSize(iconWidth, iconHeight));
+        btns.at(i)->installEventFilter(this);
+
+        this->btns.append(btns.at(i));
+        this->pixNormal.append(pixNormal);
+        this->pixDark.append(pixDark);
+    }
+}
+
+void IconHelper::setStyle(QFrame *frame, QList<QToolButton *> btns, QList<int> pixChar,
+                          quint32 iconSize, quint32 iconWidth, quint32 iconHeight,
+                          const QString &normalBgColor, const QString &darkBgColor,
+                          const QString &normalTextColor, const QString &darkTextColor)
+{
+    int btnCount = btns.count();
+    int charCount = pixChar.count();
+    if (btnCount <= 0 || charCount <= 0 || btnCount != charCount) {
+        return;
+    }
+
+    QStringList qss;
+    qss.append(QString("QFrame>QToolButton{border-style:none;border-width:0px;}"));
+    qss.append(QString("QFrame>QToolButton{background-color:%1;color:%2;}")
+               .arg(normalBgColor).arg(normalTextColor));
+    qss.append(QString("QFrame>QToolButton:hover,QFrame>QToolButton:pressed,QFrame>QToolButton:checked{background-color:%1;color:%2;}")
+               .arg(darkBgColor).arg(darkTextColor));
+
+    frame->setStyleSheet(qss.join(""));
+
+    for (int i = 0; i < btnCount; i++) {
+        //存储对应按钮对象,方便鼠标移上去的时候切换图片
+        QPixmap pixNormal = getPixmap(normalTextColor, QChar(pixChar.at(i)), iconSize, iconWidth, iconHeight);
+        QPixmap pixDark = getPixmap(darkTextColor, QChar(pixChar.at(i)), iconSize, iconWidth, iconHeight);
+
+        btns.at(i)->setIcon(QIcon(pixNormal));
+        btns.at(i)->setIconSize(QSize(iconWidth, iconHeight));
+        btns.at(i)->installEventFilter(this);
+
+        this->btns.append(btns.at(i));
+        this->pixNormal.append(pixNormal);
+        this->pixDark.append(pixDark);
+    }
+}
+
+bool IconHelper::eventFilter(QObject *watched, QEvent *event)
+{
+    if (watched->inherits("QToolButton")) {
+        QToolButton *btn = (QToolButton *)watched;
+        int index = btns.indexOf(btn);
+        if (index >= 0) {
+            if (event->type() == QEvent::Enter) {
+                btn->setIcon(QIcon(pixDark.at(index)));
+            } else if (event->type() == QEvent::Leave) {
+                if (btn->isChecked()) {
+                    btn->setIcon(QIcon(pixDark.at(index)));
+                } else {
+                    btn->setIcon(QIcon(pixNormal.at(index)));
+                }
+            }
+        }
+    }
+
+    return QObject::eventFilter(watched, event);
+}

--- a/iconhelper.h
+++ b/iconhelper.h
@@ -1,0 +1,72 @@
+﻿#ifndef ICONHELPER_H
+#define ICONHELPER_H
+
+#include <QtCore>
+#include <QtGui>
+#if (QT_VERSION > QT_VERSION_CHECK(5,0,0))
+#include <QtWidgets>
+#endif
+
+//图形字体处理类
+class IconHelper : public QObject
+{
+    Q_OBJECT//宏，建立元对象系统
+
+public:
+
+    static IconHelper *Instance();
+    //设置字体
+    explicit IconHelper(QObject *parent = 0);
+
+    //设置图标
+    //32位系统为qint32，quintptr：quint32 或 quint64
+    void setIcon(QLabel *lab, QChar c, quint32 size = 12);
+
+    //设置按钮
+     //QAbstractButton类是按钮部件的抽象基类，提供了按钮所共有的功能。
+    void setIcon(QAbstractButton *btn, QChar c, quint32 size = 12);
+
+    //绘制
+    QPixmap getPixmap(const QString &color, QChar c, quint32 size = 12,
+                      quint32 pixWidth = 10, quint32 pixHeight = 10);
+
+    //根据按钮获取该按钮对应的图标
+    QPixmap getPixmap(QToolButton *btn, bool normal);
+
+    //指定导航面板样式,不带图标
+    static void setStyle(QWidget *widget, const QString &type = "left", int borderWidth = 3,
+                         const QString &borderColor = "#029FEA",
+                         const QString &normalBgColor = "#292F38",
+                         const QString &darkBgColor = "#1D2025",
+                         const QString &normalTextColor = "#54626F",
+                         const QString &darkTextColor = "#FDFDFD");
+
+    //指定导航面板样式,带图标和效果切换
+    void setStyle(QWidget *widget, QList<QToolButton *> btns, QList<int> pixChar,
+                  quint32 iconSize = 9, quint32 iconWidth = 10, quint32 iconHeight = 10,
+                  const QString &type = "left", int borderWidth = 3,
+                  const QString &borderColor = "#029FEA",
+                  const QString &normalBgColor = "#292F38",
+                  const QString &darkBgColor = "#1D2025",
+                  const QString &normalTextColor = "#54626F",
+                  const QString &darkTextColor = "#FDFDFD");
+
+    //指定导航按钮样式,带图标和效果切换
+    void setStyle(QFrame *frame, QList<QToolButton *> btns, QList<int> pixChar,
+                  quint32 iconSize = 9, quint32 iconWidth = 10, quint32 iconHeight = 10,
+                  const QString &normalBgColor = "#2FC5A2",
+                  const QString &darkBgColor = "#3EA7E9",
+                  const QString &normalTextColor = "#EEEEEE",
+                  const QString &darkTextColor = "#FFFFFF");
+
+protected:
+    bool eventFilter(QObject *watched, QEvent *event);
+
+private:
+    static IconHelper *self;    //对象自身
+    QFont iconFont;             //图形字体
+    QList<QToolButton *> btns;  //按钮队列
+    QList<QPixmap> pixNormal;   //正常图片队列
+    QList<QPixmap> pixDark;     //加深图片队列
+};
+#endif // ICONHELPER_H

--- a/inifile.cpp
+++ b/inifile.cpp
@@ -1,0 +1,275 @@
+#include "inifile.h"
+#include <QVariant>
+#include <QDebug>
+//#include <QFileInfo>
+IniFile::IniFile(QString fileName)
+{
+    isInsertDeduplication = false;
+    isValueDeduplication = false;
+    isCoverWrite = true;
+    iniSetting = new QSettings(fileName,QSettings::IniFormat);
+}
+
+QStringList IniFile::getValue(const QString& group,const QString& key) const
+{
+    QVariant variant = iniSetting->value(QString(group +"/" + key));
+    QStringList value = variant.value<QStringList>();
+//    qDebug()<<"value:"<<value;
+    return  value;
+}
+
+QStringList IniFile::getAllKey() const
+{
+    return  iniSetting->allKeys();
+}
+
+QStringList IniFile::getKey(const QString &group) const
+{
+    iniSetting->beginGroup(group);
+    QStringList keyList = iniSetting->childKeys();
+    iniSetting->endGroup();
+    return  keyList;
+}
+
+QStringList IniFile::getGroup() const
+{
+     QStringList groupList = iniSetting->childGroups();
+     return  groupList;
+}
+
+void IniFile::saveValue(const QString& group, const QString& key, const QStringList& values)
+{
+    //结构
+    /*
+     *                {isValue:1
+             isCover->
+                     {noValue:2
+    //Cover->
+                              [isInsert:3
+                    {isValue->
+                              [noInsert:4
+             noCover->
+                           [isInsert:5
+                   {noValue
+                          [noInsert:6
+    */
+    /// \brief resVariant
+    QVariant resVariant;
+    iniSetting->beginGroup(group);
+    if(isCoverWrite){//如果覆盖写入，则直接写入
+        if(isValueDeduplication){//即将插入的值去重
+            QStringList resValues;//新建QStringList去重
+                for(int i = 0; i < values.size() ;i++){
+                     if(resValues.indexOf(values.at(i)) == -1){
+                            resValues.push_back(values.at(i));
+                      }
+                 }
+             resVariant.setValue(resValues);
+             qDebug()<<"test1";
+        }else{//即将插入的值不去重复
+            resVariant.setValue(values);
+            qDebug()<<"test2";
+        }
+    }else{//不覆盖写入
+        QVariant variant = iniSetting->value(key);
+        QStringList originalValue = variant.value<QStringList>();
+        if(isValueDeduplication){//即将插入的值去重
+            if(isInsertDeduplication){//即将插入和原有值不同的值
+                foreach(QString tempValue, values){
+                  if(originalValue.indexOf(tempValue) == -1){
+                      originalValue.push_back(tempValue);
+                  }
+                }
+                qDebug()<<"test3";
+            }else{//即将插入的值和原有值的值可以相同
+                QStringList resValues;//新建QStringList对即将插入的值去重
+                 for(int i = 0; i < values.size() ;i++){
+                      if(resValues.indexOf(values.at(i)) == -1){
+                                resValues.push_back(values.at(i));
+                       }
+                  }
+                 foreach(QString tempValue, resValues){
+                   originalValue.push_back(tempValue);
+                 }
+            }
+            qDebug()<<"test4";
+        }else{//即将插入的值不去重
+            if(isInsertDeduplication){//即将插入和原有值不同的值
+                QStringList resValues;
+                foreach(QString tempValue, values){
+                  if(originalValue.indexOf(tempValue) == -1){
+                      resValues.push_back(tempValue);
+                  }
+                }
+                foreach(QString tempValue, resValues){
+                  originalValue.push_back(tempValue);
+                }
+                qDebug()<<"test5";
+            }else{//即将插入的值和原有值可以相同
+                foreach(QString tempValue, values){
+                  originalValue.push_back(tempValue);
+                }
+                qDebug()<<"test6";
+            }
+        }
+        resVariant.setValue(originalValue);
+    }
+    iniSetting->setValue(key, resVariant);
+    iniSetting->endGroup();
+
+    //在原有的基础上进行去重复
+//    for(int i = 0; i < values.size() ;i++){
+//        for(int j = i + 1; j < values.size(); j++){
+//            int indexFind = values.indexOf(values.at(i), j);
+//            if(indexFind != -1){
+//                values.removeAt(indexFind);
+//            }
+//        }
+//    }
+
+}
+
+void IniFile::printAllGroup() const
+{
+    QStringList groupList = iniSetting->childGroups();
+    foreach (QString group, groupList) {
+        qDebug()<< "group:" << group ;
+    }
+}
+
+void IniFile::printAllKey() const
+{
+    qDebug()<< iniSetting->allKeys();
+}
+
+void IniFile::printKey(const QString& group) const
+{
+    iniSetting->beginGroup(group);
+    QStringList keyList = iniSetting->childKeys();
+    qDebug() <<"allKeys : " << keyList << endl;
+    iniSetting->endGroup();
+}
+
+void IniFile::printAllValue(const QString& group, const QString& key) const
+{
+    iniSetting->beginGroup(group);
+    QVariant variant = iniSetting->value(key);
+    QStringList valueList = variant.value<QStringList>();
+    qDebug() << "values size:" <<valueList.size();
+    qDebug() <<"allValues:" << valueList;
+    iniSetting->endGroup();
+}
+
+void IniFile::printAllInfo() const
+{
+     QStringList groupList = iniSetting->childGroups();
+     foreach(QString group, groupList){
+         qDebug() <<"group:" << group <<endl;
+         iniSetting->beginGroup(group);
+         QStringList keys = iniSetting->childKeys();
+         qDebug() <<"Keys : " << keys << endl;
+          foreach(QString key, keys)
+          {
+              QVariant variant = iniSetting->value(key);
+              QStringList values = variant.value<QStringList>();
+              qDebug() << "values size:" <<values.size() << endl;
+              qDebug() <<"allValues:" << values<< endl;
+          }
+         iniSetting->endGroup();
+     }
+}
+
+void IniFile::clear()
+{
+    iniSetting->clear();
+}
+
+QString IniFile::getFilePath() const
+{
+    return iniSetting->fileName();
+}
+
+void IniFile::onInsertDeduplication()
+{
+    isInsertDeduplication = true;
+}
+
+void IniFile::offInsertDeduplication()
+{
+    isInsertDeduplication = false;
+}
+
+void IniFile::onCoverWrite()
+{
+    isCoverWrite = true;
+}
+
+void IniFile::offCoverWrite()
+{
+    isCoverWrite = false;
+}
+
+void IniFile::remove(const QString& group, const QString& key)
+{
+    iniSetting->beginGroup(group);
+    iniSetting->remove(key);
+    iniSetting->endGroup();
+}
+
+void IniFile::remove(const QString& group)
+{
+    iniSetting->beginGroup(group);
+    iniSetting->remove("");
+    iniSetting->endGroup();
+}
+
+bool IniFile::hasKey(const QString &group, const QString &key) const
+{
+    bool res;
+    iniSetting->beginGroup(group);
+    res =  iniSetting->contains(key);
+    iniSetting->endGroup();
+    return res;
+}
+
+bool IniFile::hasGroup(const QString& group) const
+{
+    QStringList groupList = iniSetting->childGroups();
+//    qDebug()<<"groupList:"<<groupList;
+    if(groupList.indexOf(group) == -1){
+        return false;
+    }else{
+        return  true;
+    }
+}
+
+bool IniFile::hasValue(const QString& group, const QString& key,  const QString& value) const
+{
+    bool res;
+    iniSetting->beginGroup(group);
+    QVariant variant = iniSetting->value(key);
+    QStringList valueList = variant.value<QStringList>();
+    if(valueList.indexOf(value) == -1){
+        res = false;
+    }else{
+        res = true;
+    }
+    iniSetting->endGroup();
+    return  res;
+}
+
+void IniFile::onValueDeduplication()
+{
+    isValueDeduplication = true;
+}
+
+void IniFile::offValueDeduplication()
+{
+    isValueDeduplication = false;
+}
+
+
+
+
+
+

--- a/inifile.h
+++ b/inifile.h
@@ -1,0 +1,76 @@
+#ifndef INIFILE_H
+#define INIFILE_H
+
+#include<QSettings>
+#include <QString>
+#include <QStringList>
+#include <QDebug>
+
+class IniFile
+{
+public:
+    explicit IniFile():iniSetting(nullptr),isCoverWrite(true),isInsertDeduplication(false),isValueDeduplication(false){}
+    IniFile(QString);
+    ~IniFile(){delete  iniSetting;}
+
+    //获得值
+    //返回group的key下的value
+    QStringList getValue(const QString&,const  QString&) const;
+    //返回所有key
+    QStringList getAllKey() const;
+    //返回group的所有key
+    QStringList getKey(const QString&) const;
+    //返回所有group
+    QStringList getGroup() const;
+    //返回当前ini文件的路径
+    QString getFilePath() const;
+    //在group的key下写入value
+    void saveValue(const QString& , const QString& , const  QStringList&);
+
+    //打印信息
+    //打印所有组
+    void printAllGroup() const;
+    //打印所有key
+    void printAllKey() const;
+    //打印group下的所有key
+    void printKey(const QString&) const;
+    //打印group的key下的所有value
+    void printAllValue(const QString&,const QString&) const;
+    //打印所有group的全部信息
+    void printAllInfo() const;
+
+
+    //删除操作
+    //删除所有group
+    void clear();
+    //移除group下的key
+    void remove(const QString&, const QString&);
+    //移除group
+    void remove(const QString&);
+
+    //判断当前group下是否有key
+    bool hasKey(const QString&,const QString&) const;
+    bool hasGroup(const QString&) const;
+    bool hasValue(const QString&, const QString&, const QString&) const;
+
+    //打开或关闭写入和原值不重复的value
+    void onInsertDeduplication();
+    void offInsertDeduplication();
+    //打开或关闭对即将写的value去重
+    void onValueDeduplication();
+    void offValueDeduplication();
+    //打开或关闭覆盖写入value
+    void onCoverWrite();
+    void offCoverWrite();
+
+private:
+    QSettings* iniSetting;//指向QSettings对象的指针
+    bool isCoverWrite;//是否覆盖写入value
+    bool isInsertDeduplication;//是否插入重复的value
+    bool isValueDeduplication;//对即将插入的值去重复
+    //不允许复制操作
+    IniFile(const IniFile&);//复制操作符函数
+    IniFile& operator=(const IniFile&);//赋值操作符函数
+};
+
+#endif // INIFILE_H

--- a/login.qrc
+++ b/login.qrc
@@ -1,0 +1,10 @@
+<RCC>
+    <qresource prefix="/">
+        <file>image/logn_account.png</file>
+        <file>image/logn_password.png</file>
+        <file>image/login_background1.png</file>
+        <file>image/login_background2.png</file>
+        <file>image/yasuo.gif</file>
+        <file>music/LOL.mp3</file>
+    </qresource>
+</RCC>

--- a/logindialog.cpp
+++ b/logindialog.cpp
@@ -1,0 +1,214 @@
+#include "logindialog.h"
+#include "ui_logindialog.h"
+
+#include "connnection.h"
+#include <QMessageBox>
+#include <QDebug>
+#include <QSqlDatabase>
+#include <QSqlQuery>
+
+#include "iconhelper.h"
+
+#include <QBitmap>
+#include <QPainter>
+#include <QMediaPlaylist>
+
+LoginDialog::LoginDialog(QWidget *parent) :
+    QDialog(parent, Qt::FramelessWindowHint),
+    ui(new Ui::LoginDialog)
+{
+    ui->setupUi(this);
+
+    ui->passwordLineEdit->setEchoMode(QLineEdit::Password);
+
+    ui->loginButton->setStyleSheet("background-color: rgba(255, 255, 255, 20%;border:none)");
+    ui->loginButton->setFlat(true);
+
+    //设置关闭按钮
+    IconHelper::Instance()->setIcon(ui->loginCloseButton, QChar(0xf00d));
+
+//    QPalette palette;
+//    //palette.setColor(QPalette::Background,QColor("red"));
+//    palette.setBrush(QPalette::Background,QBrush(QPixmap(":/img/img1.png").scaled(this->size())));
+//    this->setPalette(palette);
+    QPixmap plx;
+    plx.load(":/image/logn_account.png");
+    QPixmap* imgPointer = &plx;
+    imgPointer->scaled(ui->accountLabel->size(), Qt::IgnoreAspectRatio);
+    ui->accountLabel->setScaledContents(true);
+    ui->accountLabel->setPixmap(plx);
+
+    ui->accountLabel->show();
+
+    plx.load(":/image/logn_password.png");
+    imgPointer->scaled(ui->passwordLabel->size(), Qt::IgnoreAspectRatio);
+    ui->passwordLabel->setScaledContents(true);
+    ui->passwordLabel->setPixmap(plx);
+    //;border:1px solid #
+    ui->passwordLineEdit->setStyleSheet("background-color: rgba(255, 255, 255, 10%)");
+    ui->passwordLabel->show();
+
+    //背景图片
+    QMovie *iconShow = new QMovie(":/image/yasuo.gif");
+    ui->backgroundLabel->setMovie(iconShow);
+    iconShow->start();
+    this->setStyleSheet("QDialog{border-image: url(:/image/login_background1.png);}");
+    //循环播放音乐（暂时关闭）
+    ///playBackgroundMusic();
+
+    //棱角圆滑
+     QBitmap bmp(this->size());
+     bmp.fill();
+     QPainter p(&bmp);
+     p.setPen(Qt::NoPen);
+     p.setBrush(Qt::black);
+     p.setPen(Qt::transparent);//表示RGBA值为(0,0,0,0)的透明色。
+     p.setRenderHint(QPainter::Antialiasing); // 反锯齿;
+     p.drawRoundedRect(bmp.rect(), 20, 20);
+     setMask(bmp);
+
+    //设置界面标题
+    this->setWindowTitle("战略家麻将平台");
+
+    //下拉框
+    ui->accountComboBox->setEditable(true);//可以编辑
+    ui->accountComboBox->lineEdit()->setMaxLength(10);//输入的长度
+    ui->accountComboBox->setStyleSheet("background-color: rgba(255, 255, 255, 10%;border:none)");
+    //使用 QStringLiteral 宏可以在编译期把代码里的常量字符串 str
+    //直接构造为 QString 对象，于是运行时就不再需要额外的构造开销了。
+    ui->accountComboBox->lineEdit()->setPlaceholderText(QStringLiteral("请输入用户名"));
+    ui->passwordLineEdit->setPlaceholderText(QStringLiteral("请输入密码"));
+
+    initUsernameList();
+}
+
+LoginDialog::~LoginDialog()
+{
+    delete ui;
+}
+
+void LoginDialog::on_loginButton_clicked()
+{
+    username = ui->accountComboBox->currentText() ;
+    password = ui->passwordLineEdit->text();
+
+    QMessageBox *msgBox = new QMessageBox();
+    QPixmap iconImg(":/image/login_background1.png");
+    QIcon icon(iconImg);
+    msgBox->setWindowIcon(icon);
+
+
+    if(username.isEmpty()){
+        QMessageBox::information(this, tr("请输入账号"),tr("请先输入账号再登陆，谢谢！"),
+                                 QMessageBox::Ok);
+        ui->accountComboBox->setFocus();
+    }else if(password.isEmpty()){
+        QMessageBox::information(this, tr("请输入密码"),tr("请先输入密码再登陆，谢谢！"),
+                                 QMessageBox::Ok);
+        ui->passwordLineEdit->setFocus();
+    }else{
+         if(!createConnection()){
+             QMessageBox::information(this, tr("提示"),tr("请先连接网络，谢谢！"),
+                                      QMessageBox::Ok);
+         }else{
+             QSqlDatabase db = QSqlDatabase::database("connection1");
+             QSqlQuery query(db);
+
+             QString str = QString("select * from user where account = '%0' and password = '%1'").arg(username).arg(password);
+             query.exec(str);
+             int record = query.size();
+             //qDebug() << "record:" << record<< endl;
+
+//             while(query.next()){
+//                   qDebug() << query.value(0).toInt() <<query.value(1).toInt()
+//                                      <<query.value(2).toString() <<query.value(3).toString();
+//              }
+
+             //未连接上数据库返回-1，连接上查询失败返回0，查到返回1
+             if(record == -1 || record == 0){
+                  QMessageBox::information(this,tr("提示"),tr("用户名或密码错误！"),QMessageBox::Ok);
+                  ui->passwordLineEdit->clear();
+                  ui->passwordLineEdit->setFocus();
+             }else{
+                 QMessageBox::information(this,tr("提示"),tr("登陆成功！"),QMessageBox::Ok);
+                 //QDialog::accept();
+                 if(isrembered == 1){
+                     //qDebug() << " m_userNameList.push_front(username)"<<endl;
+                     m_userNameList.push_back(username);
+                     writeUsernameList(m_userNameList);
+
+                 }
+                 //停止音乐
+                 backgroundMusic->stop();
+
+                 //清空密码
+                 ui->accountComboBox->clear();
+                 ui->passwordLineEdit->clear();
+                // ui->accountLineEdit->setFocus();
+                 ui->accountCheckBox->setFocus();
+                 emit mainwidgetShow();
+                 this->close();
+
+             }
+
+         }
+     }
+}
+
+ void LoginDialog::on_loginCloseButton_clicked()
+{
+    exit(0);
+}
+
+void LoginDialog::writeUsernameList(QStringList& values)
+{
+    QString fileName = QCoreApplication::applicationDirPath() + "/login.ini";
+    IniFile iniUsername(fileName);
+    iniUsername.offCoverWrite();
+    iniUsername.onValueDeduplication();
+    iniUsername.onInsertDeduplication();
+    iniUsername.saveValue(QString("config"),QString("username"), values);
+}
+
+void LoginDialog::initUsernameList()
+{
+    QString fileName = QCoreApplication::applicationDirPath() + "/login.ini";
+    IniFile iniUsername(fileName);
+    m_userNameList = iniUsername.getValue(QString("config"),QString("username"));
+    ui->accountComboBox->addItems(m_userNameList);
+
+    if(m_userNameList.size()>0){
+        username = m_userNameList.at(0);
+        qDebug() <<"m_userNameList.at(0)" << m_userNameList.at(0);
+    }
+
+    if(isrembered == 1)
+    {
+        ui->accountCheckBox->setChecked(true);
+        ui->accountComboBox->setCurrentText(username);
+    }
+}
+
+void LoginDialog::playBackgroundMusic()
+{
+    QMediaPlaylist *playlist = new QMediaPlaylist();
+    playlist->addMedia(QUrl("qrc:/music/LOL.mp3"));
+    playlist->setPlaybackMode(QMediaPlaylist::Loop);
+
+    backgroundMusic = new QMediaPlayer();
+    backgroundMusic->setPlaylist(playlist);
+    backgroundMusic->setVolume(100);
+    backgroundMusic->play();
+}
+
+
+void LoginDialog::on_accountCheckBox_clicked()
+{
+    if(ui->accountCheckBox->isChecked()){
+          isrembered = 1;
+          qDebug() << "isrembered = true";
+      }else{
+          isrembered = 0;
+          qDebug() << "isrembered = false";
+      }
+}

--- a/logindialog.h
+++ b/logindialog.h
@@ -1,0 +1,51 @@
+#ifndef LOGINDIALOG_H
+#define LOGINDIALOG_H
+
+#include <QDialog>
+
+#include "mainwidget.h"
+#include "inifile.h"
+#include <QMediaPlayer>
+
+namespace Ui {
+class LoginDialog;
+}
+
+class LoginDialog : public QDialog
+{
+    Q_OBJECT
+    friend class UIMainWindows;
+public:
+    explicit LoginDialog(QWidget *parent = nullptr);
+    ~LoginDialog();
+
+private slots://按钮
+    void on_loginButton_clicked();//登陆按钮
+    void on_loginCloseButton_clicked();//关闭界面按钮
+
+    void on_accountCheckBox_clicked();
+
+private:
+    Ui::LoginDialog *ui;
+
+    //背景音乐
+    QMediaPlayer *backgroundMusic;
+    //记住的用户名
+    QStringList m_userNameList;//记录的账号
+    int isrembered;//是否记住账户
+    QString username;
+    QString password;
+
+private:
+    void writeUsernameList(QStringList&);
+
+signals:
+    void mainwidgetShow();//显示主窗口
+    void tcpHeartBeat();//心跳信号
+public slots:
+    void initUsernameList();//加载账号
+    void playBackgroundMusic();//播放背景音乐
+
+};
+
+#endif // LOGINDIALOG_H

--- a/logindialog.ui
+++ b/logindialog.ui
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>LoginDialog</class>
+ <widget class="QDialog" name="LoginDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>852</width>
+    <height>480</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QPushButton" name="loginButton">
+   <property name="geometry">
+    <rect>
+     <x>420</x>
+     <y>250</y>
+     <width>71</width>
+     <height>24</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>登陆</string>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="loginCloseButton">
+   <property name="geometry">
+    <rect>
+     <x>810</x>
+     <y>0</y>
+     <width>43</width>
+     <height>30</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string/>
+   </property>
+  </widget>
+  <widget class="QCheckBox" name="accountCheckBox">
+   <property name="geometry">
+    <rect>
+     <x>510</x>
+     <y>170</y>
+     <width>86</width>
+     <height>22</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>记住账号</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="passwordLabel">
+   <property name="geometry">
+    <rect>
+     <x>300</x>
+     <y>210</y>
+     <width>45</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>密码(&amp;P)</string>
+   </property>
+   <property name="buddy">
+    <cstring>passwordLineEdit</cstring>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="passwordLineEdit">
+   <property name="geometry">
+    <rect>
+     <x>360</x>
+     <y>210</y>
+     <width>131</width>
+     <height>24</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QLabel" name="accountLabel">
+   <property name="geometry">
+    <rect>
+     <x>300</x>
+     <y>170</y>
+     <width>43</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>账号(&amp;A)</string>
+   </property>
+   <property name="buddy">
+    <cstring>accountComboBox</cstring>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="accountComboBox">
+   <property name="geometry">
+    <rect>
+     <x>360</x>
+     <y>170</y>
+     <width>131</width>
+     <height>24</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QLabel" name="backgroundLabel">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>852</width>
+     <height>480</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string/>
+   </property>
+  </widget>
+  <zorder>backgroundLabel</zorder>
+  <zorder>loginButton</zorder>
+  <zorder>loginCloseButton</zorder>
+  <zorder>accountCheckBox</zorder>
+  <zorder>passwordLabel</zorder>
+  <zorder>passwordLineEdit</zorder>
+  <zorder>accountLabel</zorder>
+  <zorder>accountComboBox</zorder>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -133,7 +133,7 @@ void UIMainWindows::initForm()
     //ui->widgetMenu->setVisible(false);
     ui->widgetTitle->setProperty("form", "title");
     ui->widgetTop->setProperty("nav", "top");
-    ui->labTitle->setText("战略家麻将平台");
+    ui->labTitle->setText("战略麻将平台");
    // ui->labTitle->setFont(QFont("Microsoft Yahei", 20));
     this->setWindowTitle(ui->labTitle->text());
 

--- a/mainwidget.h
+++ b/mainwidget.h
@@ -3,7 +3,7 @@
 #ifndef MAINWIDGET_H
 #define MAINWIDGET_H
 
-#include <QWidget>
+#include <QtWidgets/QWidget>
 
 #include<QSystemTrayIcon>
 #include <QMenu>

--- a/mainwidget.ui
+++ b/mainwidget.ui
@@ -249,7 +249,2417 @@
             <size>
              <width>20</width>
              <height>40</height>
-     
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="0" column="1">
+          <widget class="QPushButton" name="btnMenu_Min">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>30</width>
+             <height>30</height>
+            </size>
+           </property>
+           <property name="cursor">
+            <cursorShape>ArrowCursor</cursorShape>
+           </property>
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
+           </property>
+           <property name="toolTip">
+            <string>最小化</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="3">
+          <widget class="QPushButton" name="btnMenu_Close">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>30</width>
+             <height>30</height>
+            </size>
+           </property>
+           <property name="cursor">
+            <cursorShape>ArrowCursor</cursorShape>
+           </property>
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
+           </property>
+           <property name="toolTip">
+            <string>关闭</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QPushButton" name="btnMenu_Max">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>30</width>
+             <height>30</height>
+            </size>
+           </property>
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QStackedWidget" name="stackedWidget">
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="currentIndex">
+      <number>1</number>
+     </property>
+     <widget class="QWidget" name="page1">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QWidget" name="widgetLeftMain" native="true">
+         <property name="maximumSize">
+          <size>
+           <width>90</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QToolButton" name="tbtnMain1">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>识别</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QToolButton" name="tbtnMain2">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>改牌</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QToolButton" name="tbtnMain3">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>游戏</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>471</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QStackedWidget" name="mainStackedWidget">
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <widget class="QWidget" name="gamePage">
+          <widget class="QLabel" name="handSouth1">
+           <property name="geometry">
+            <rect>
+             <x>260</x>
+             <y>608</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handSouth2">
+           <property name="geometry">
+            <rect>
+             <x>295</x>
+             <y>608</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handSouth3">
+           <property name="geometry">
+            <rect>
+             <x>330</x>
+             <y>608</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handSouth4">
+           <property name="geometry">
+            <rect>
+             <x>365</x>
+             <y>608</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handSouth5">
+           <property name="geometry">
+            <rect>
+             <x>400</x>
+             <y>608</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handSouth6">
+           <property name="geometry">
+            <rect>
+             <x>435</x>
+             <y>608</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handSouth7">
+           <property name="geometry">
+            <rect>
+             <x>470</x>
+             <y>608</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handSouth8">
+           <property name="geometry">
+            <rect>
+             <x>505</x>
+             <y>608</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handSouth9">
+           <property name="geometry">
+            <rect>
+             <x>540</x>
+             <y>608</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handSouth13">
+           <property name="geometry">
+            <rect>
+             <x>680</x>
+             <y>608</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionSouth10">
+           <property name="geometry">
+            <rect>
+             <x>296</x>
+             <y>664</y>
+             <width>30</width>
+             <height>40</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handSouth14">
+           <property name="geometry">
+            <rect>
+             <x>715</x>
+             <y>608</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handSouth11">
+           <property name="geometry">
+            <rect>
+             <x>610</x>
+             <y>608</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handSouth12">
+           <property name="geometry">
+            <rect>
+             <x>645</x>
+             <y>608</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handSouth10">
+           <property name="geometry">
+            <rect>
+             <x>575</x>
+             <y>608</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionSouth9">
+           <property name="geometry">
+            <rect>
+             <x>326</x>
+             <y>664</y>
+             <width>30</width>
+             <height>40</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionSouth8">
+           <property name="geometry">
+            <rect>
+             <x>356</x>
+             <y>664</y>
+             <width>30</width>
+             <height>40</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionSouth7">
+           <property name="geometry">
+            <rect>
+             <x>386</x>
+             <y>664</y>
+             <width>30</width>
+             <height>40</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionSouth6">
+           <property name="geometry">
+            <rect>
+             <x>416</x>
+             <y>664</y>
+             <width>30</width>
+             <height>40</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionSouth5">
+           <property name="geometry">
+            <rect>
+             <x>446</x>
+             <y>664</y>
+             <width>30</width>
+             <height>40</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionSouth4">
+           <property name="geometry">
+            <rect>
+             <x>476</x>
+             <y>664</y>
+             <width>30</width>
+             <height>40</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionSouth3">
+           <property name="geometry">
+            <rect>
+             <x>506</x>
+             <y>664</y>
+             <width>30</width>
+             <height>40</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionSouth2">
+           <property name="geometry">
+            <rect>
+             <x>536</x>
+             <y>664</y>
+             <width>30</width>
+             <height>40</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionSouth1">
+           <property name="geometry">
+            <rect>
+             <x>566</x>
+             <y>664</y>
+             <width>30</width>
+             <height>40</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handWest14">
+           <property name="geometry">
+            <rect>
+             <x>136</x>
+             <y>490</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handWest13">
+           <property name="geometry">
+            <rect>
+             <x>136</x>
+             <y>455</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handWest12">
+           <property name="geometry">
+            <rect>
+             <x>136</x>
+             <y>420</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handWest11">
+           <property name="geometry">
+            <rect>
+             <x>136</x>
+             <y>385</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handWest10">
+           <property name="geometry">
+            <rect>
+             <x>136</x>
+             <y>350</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handWest9">
+           <property name="geometry">
+            <rect>
+             <x>136</x>
+             <y>315</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handWest8">
+           <property name="geometry">
+            <rect>
+             <x>136</x>
+             <y>280</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handWest7">
+           <property name="geometry">
+            <rect>
+             <x>136</x>
+             <y>245</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handWest6">
+           <property name="geometry">
+            <rect>
+             <x>136</x>
+             <y>210</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handWest5">
+           <property name="geometry">
+            <rect>
+             <x>136</x>
+             <y>175</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handWest4">
+           <property name="geometry">
+            <rect>
+             <x>136</x>
+             <y>140</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handWest3">
+           <property name="geometry">
+            <rect>
+             <x>136</x>
+             <y>105</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handWest2">
+           <property name="geometry">
+            <rect>
+             <x>136</x>
+             <y>70</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handWest1">
+           <property name="geometry">
+            <rect>
+             <x>136</x>
+             <y>35</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionWest10">
+           <property name="geometry">
+            <rect>
+             <x>96</x>
+             <y>48</y>
+             <width>40</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionWest9">
+           <property name="geometry">
+            <rect>
+             <x>96</x>
+             <y>78</y>
+             <width>40</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionWest8">
+           <property name="geometry">
+            <rect>
+             <x>96</x>
+             <y>108</y>
+             <width>40</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionWest7">
+           <property name="geometry">
+            <rect>
+             <x>96</x>
+             <y>138</y>
+             <width>40</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionWest6">
+           <property name="geometry">
+            <rect>
+             <x>96</x>
+             <y>168</y>
+             <width>40</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionWest5">
+           <property name="geometry">
+            <rect>
+             <x>96</x>
+             <y>198</y>
+             <width>40</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionWest4">
+           <property name="geometry">
+            <rect>
+             <x>96</x>
+             <y>228</y>
+             <width>40</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionWest3">
+           <property name="geometry">
+            <rect>
+             <x>96</x>
+             <y>258</y>
+             <width>40</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionWest2">
+           <property name="geometry">
+            <rect>
+             <x>96</x>
+             <y>288</y>
+             <width>40</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionWest1">
+           <property name="geometry">
+            <rect>
+             <x>96</x>
+             <y>318</y>
+             <width>40</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handEast1">
+           <property name="geometry">
+            <rect>
+             <x>976</x>
+             <y>639</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handEast2">
+           <property name="geometry">
+            <rect>
+             <x>976</x>
+             <y>604</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handEast14">
+           <property name="geometry">
+            <rect>
+             <x>976</x>
+             <y>184</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handEast3">
+           <property name="geometry">
+            <rect>
+             <x>976</x>
+             <y>569</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handEast4">
+           <property name="geometry">
+            <rect>
+             <x>976</x>
+             <y>534</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handEast5">
+           <property name="geometry">
+            <rect>
+             <x>976</x>
+             <y>499</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handEast6">
+           <property name="geometry">
+            <rect>
+             <x>976</x>
+             <y>464</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handEast7">
+           <property name="geometry">
+            <rect>
+             <x>976</x>
+             <y>429</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handEast8">
+           <property name="geometry">
+            <rect>
+             <x>976</x>
+             <y>394</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handEast9">
+           <property name="geometry">
+            <rect>
+             <x>976</x>
+             <y>359</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handEast10">
+           <property name="geometry">
+            <rect>
+             <x>976</x>
+             <y>324</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handEast11">
+           <property name="geometry">
+            <rect>
+             <x>976</x>
+             <y>289</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handEast12">
+           <property name="geometry">
+            <rect>
+             <x>976</x>
+             <y>254</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handEast13">
+           <property name="geometry">
+            <rect>
+             <x>976</x>
+             <y>219</y>
+             <width>55</width>
+             <height>35</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionEast1">
+           <property name="geometry">
+            <rect>
+             <x>1031</x>
+             <y>358</y>
+             <width>40</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionEast2">
+           <property name="geometry">
+            <rect>
+             <x>1031</x>
+             <y>388</y>
+             <width>40</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionEast3">
+           <property name="geometry">
+            <rect>
+             <x>1031</x>
+             <y>418</y>
+             <width>40</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionEast4">
+           <property name="geometry">
+            <rect>
+             <x>1031</x>
+             <y>448</y>
+             <width>40</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionEast5">
+           <property name="geometry">
+            <rect>
+             <x>1031</x>
+             <y>478</y>
+             <width>40</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionEast6">
+           <property name="geometry">
+            <rect>
+             <x>1031</x>
+             <y>508</y>
+             <width>40</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionEast7">
+           <property name="geometry">
+            <rect>
+             <x>1031</x>
+             <y>538</y>
+             <width>40</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionEast8">
+           <property name="geometry">
+            <rect>
+             <x>1031</x>
+             <y>568</y>
+             <width>40</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionEast9">
+           <property name="geometry">
+            <rect>
+             <x>1031</x>
+             <y>598</y>
+             <width>40</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionEast10">
+           <property name="geometry">
+            <rect>
+             <x>1031</x>
+             <y>628</y>
+             <width>40</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handNorth18">
+           <property name="geometry">
+            <rect>
+             <x>260</x>
+             <y>48</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handNorth17">
+           <property name="geometry">
+            <rect>
+             <x>295</x>
+             <y>48</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handNorth16">
+           <property name="geometry">
+            <rect>
+             <x>330</x>
+             <y>48</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handNorth15">
+           <property name="geometry">
+            <rect>
+             <x>365</x>
+             <y>48</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handNorth14">
+           <property name="geometry">
+            <rect>
+             <x>400</x>
+             <y>48</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handNorth13">
+           <property name="geometry">
+            <rect>
+             <x>435</x>
+             <y>48</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handNorth12">
+           <property name="geometry">
+            <rect>
+             <x>470</x>
+             <y>48</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handNorth11">
+           <property name="geometry">
+            <rect>
+             <x>505</x>
+             <y>48</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handNorth10">
+           <property name="geometry">
+            <rect>
+             <x>540</x>
+             <y>48</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handNorth9">
+           <property name="geometry">
+            <rect>
+             <x>575</x>
+             <y>48</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handNorth8">
+           <property name="geometry">
+            <rect>
+             <x>610</x>
+             <y>48</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handNorth7">
+           <property name="geometry">
+            <rect>
+             <x>645</x>
+             <y>48</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handNorth6">
+           <property name="geometry">
+            <rect>
+             <x>680</x>
+             <y>48</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="handNorth5">
+           <property name="geometry">
+            <rect>
+             <x>715</x>
+             <y>48</y>
+             <width>35</width>
+             <height>55</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionNorth10">
+           <property name="geometry">
+            <rect>
+             <x>826</x>
+             <y>8</y>
+             <width>30</width>
+             <height>40</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionNorth9">
+           <property name="geometry">
+            <rect>
+             <x>796</x>
+             <y>8</y>
+             <width>30</width>
+             <height>40</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionNorth8">
+           <property name="geometry">
+            <rect>
+             <x>766</x>
+             <y>8</y>
+             <width>30</width>
+             <height>40</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionNorth7">
+           <property name="geometry">
+            <rect>
+             <x>736</x>
+             <y>8</y>
+             <width>30</width>
+             <height>40</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionNorth6">
+           <property name="geometry">
+            <rect>
+             <x>706</x>
+             <y>8</y>
+             <width>30</width>
+             <height>40</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionNorth5">
+           <property name="geometry">
+            <rect>
+             <x>676</x>
+             <y>8</y>
+             <width>30</width>
+             <height>40</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionNorth4">
+           <property name="geometry">
+            <rect>
+             <x>646</x>
+             <y>8</y>
+             <width>30</width>
+             <height>40</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionNorth3">
+           <property name="geometry">
+            <rect>
+             <x>616</x>
+             <y>8</y>
+             <width>30</width>
+             <height>40</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionNorth2">
+           <property name="geometry">
+            <rect>
+             <x>586</x>
+             <y>8</y>
+             <width>30</width>
+             <height>40</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="predictionNorth1">
+           <property name="geometry">
+            <rect>
+             <x>556</x>
+             <y>8</y>
+             <width>31</width>
+             <height>40</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest2_1">
+           <property name="geometry">
+            <rect>
+             <x>296</x>
+             <y>523</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest2_2">
+           <property name="geometry">
+            <rect>
+             <x>296</x>
+             <y>503</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest2_3">
+           <property name="geometry">
+            <rect>
+             <x>296</x>
+             <y>483</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest2_4">
+           <property name="geometry">
+            <rect>
+             <x>296</x>
+             <y>463</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest2_5">
+           <property name="geometry">
+            <rect>
+             <x>296</x>
+             <y>443</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest2_6">
+           <property name="geometry">
+            <rect>
+             <x>296</x>
+             <y>423</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest2_7">
+           <property name="geometry">
+            <rect>
+             <x>296</x>
+             <y>403</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest2_8">
+           <property name="geometry">
+            <rect>
+             <x>296</x>
+             <y>383</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest2_9">
+           <property name="geometry">
+            <rect>
+             <x>296</x>
+             <y>363</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest2_10">
+           <property name="geometry">
+            <rect>
+             <x>296</x>
+             <y>343</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest2_11">
+           <property name="geometry">
+            <rect>
+             <x>296</x>
+             <y>323</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest2_12">
+           <property name="geometry">
+            <rect>
+             <x>296</x>
+             <y>303</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest2_13">
+           <property name="geometry">
+            <rect>
+             <x>296</x>
+             <y>283</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest1_1">
+           <property name="geometry">
+            <rect>
+             <x>326</x>
+             <y>523</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest1_2">
+           <property name="geometry">
+            <rect>
+             <x>326</x>
+             <y>503</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest1_3">
+           <property name="geometry">
+            <rect>
+             <x>326</x>
+             <y>483</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest1_4">
+           <property name="geometry">
+            <rect>
+             <x>326</x>
+             <y>463</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest1_5">
+           <property name="geometry">
+            <rect>
+             <x>326</x>
+             <y>443</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest1_6">
+           <property name="geometry">
+            <rect>
+             <x>326</x>
+             <y>423</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest1_7">
+           <property name="geometry">
+            <rect>
+             <x>326</x>
+             <y>403</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest1_8">
+           <property name="geometry">
+            <rect>
+             <x>326</x>
+             <y>383</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest1_9">
+           <property name="geometry">
+            <rect>
+             <x>326</x>
+             <y>363</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest1_10">
+           <property name="geometry">
+            <rect>
+             <x>326</x>
+             <y>343</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest1_11">
+           <property name="geometry">
+            <rect>
+             <x>326</x>
+             <y>323</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest1_12">
+           <property name="geometry">
+            <rect>
+             <x>326</x>
+             <y>303</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawWest1_13">
+           <property name="geometry">
+            <rect>
+             <x>326</x>
+             <y>283</y>
+             <width>30</width>
+             <height>20</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth1_14">
+           <property name="geometry">
+            <rect>
+             <x>490</x>
+             <y>515</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth1_13">
+           <property name="geometry">
+            <rect>
+             <x>510</x>
+             <y>515</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth1_12">
+           <property name="geometry">
+            <rect>
+             <x>530</x>
+             <y>515</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth1_11">
+           <property name="geometry">
+            <rect>
+             <x>550</x>
+             <y>515</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth1_10">
+           <property name="geometry">
+            <rect>
+             <x>570</x>
+             <y>515</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth1_9">
+           <property name="geometry">
+            <rect>
+             <x>590</x>
+             <y>515</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth1_8">
+           <property name="geometry">
+            <rect>
+             <x>610</x>
+             <y>515</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth1_7">
+           <property name="geometry">
+            <rect>
+             <x>630</x>
+             <y>515</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth1_6">
+           <property name="geometry">
+            <rect>
+             <x>650</x>
+             <y>515</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth1_5">
+           <property name="geometry">
+            <rect>
+             <x>670</x>
+             <y>515</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth1_4">
+           <property name="geometry">
+            <rect>
+             <x>690</x>
+             <y>515</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth1_3">
+           <property name="geometry">
+            <rect>
+             <x>710</x>
+             <y>515</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth1_2">
+           <property name="geometry">
+            <rect>
+             <x>730</x>
+             <y>515</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth2_14">
+           <property name="geometry">
+            <rect>
+             <x>490</x>
+             <y>545</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth2_13">
+           <property name="geometry">
+            <rect>
+             <x>510</x>
+             <y>545</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth2_12">
+           <property name="geometry">
+            <rect>
+             <x>530</x>
+             <y>545</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth2_11">
+           <property name="geometry">
+            <rect>
+             <x>550</x>
+             <y>545</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth2_10">
+           <property name="geometry">
+            <rect>
+             <x>570</x>
+             <y>545</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth2_9">
+           <property name="geometry">
+            <rect>
+             <x>590</x>
+             <y>545</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth2_8">
+           <property name="geometry">
+            <rect>
+             <x>610</x>
+             <y>545</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth2_7">
+           <property name="geometry">
+            <rect>
+             <x>630</x>
+             <y>545</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth2_6">
+           <property name="geometry">
+            <rect>
+             <x>650</x>
+             <y>545</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth2_5">
+           <property name="geometry">
+            <rect>
+             <x>670</x>
+             <y>545</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth2_4">
+           <property name="geometry">
+            <rect>
+             <x>690</x>
+             <y>545</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth2_3">
+           <property name="geometry">
+            <rect>
+             <x>710</x>
+             <y>545</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawSouth2_2">
+           <property name="geometry">
+            <rect>
+             <x>730</x>
+             <y>545</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth2_1">
+           <property name="geometry">
+            <rect>
+             <x>380</x>
+             <y>185</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth2_2">
+           <property name="geometry">
+            <rect>
+             <x>400</x>
+             <y>185</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth2_3">
+           <property name="geometry">
+            <rect>
+             <x>420</x>
+             <y>185</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth2_4">
+           <property name="geometry">
+            <rect>
+             <x>440</x>
+             <y>185</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth2_5">
+           <property name="geometry">
+            <rect>
+             <x>460</x>
+             <y>185</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth2_7">
+           <property name="geometry">
+            <rect>
+             <x>500</x>
+             <y>185</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth2_6">
+           <property name="geometry">
+            <rect>
+             <x>480</x>
+             <y>185</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth2_8">
+           <property name="geometry">
+            <rect>
+             <x>520</x>
+             <y>185</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth2_9">
+           <property name="geometry">
+            <rect>
+             <x>540</x>
+             <y>185</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth2_10">
+           <property name="geometry">
+            <rect>
+             <x>560</x>
+             <y>185</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth2_11">
+           <property name="geometry">
+            <rect>
+             <x>580</x>
+             <y>185</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth2_12">
+           <property name="geometry">
+            <rect>
+             <x>600</x>
+             <y>185</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth2_13">
+           <property name="geometry">
+            <rect>
+             <x>620</x>
+             <y>185</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth1_1">
+           <property name="geometry">
+            <rect>
+             <x>380</x>
+             <y>155</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth1_2">
+           <property name="geometry">
+            <rect>
+             <x>400</x>
+             <y>155</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth1_3">
+           <property name="geometry">
+            <rect>
+             <x>420</x>
+             <y>155</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth1_4">
+           <property name="geometry">
+            <rect>
+             <x>440</x>
+             <y>155</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth1_5">
+           <property name="geometry">
+            <rect>
+             <x>460</x>
+             <y>155</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth1_6">
+           <property name="geometry">
+            <rect>
+             <x>480</x>
+             <y>155</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth1_7">
+           <property name="geometry">
+            <rect>
+             <x>500</x>
+             <y>155</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth1_8">
+           <property name="geometry">
+            <rect>
+             <x>520</x>
+             <y>155</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth1_9">
+           <property name="geometry">
+            <rect>
+             <x>540</x>
+             <y>155</y>
+             <width>20</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+          <widget class="QLabel" name="drawNorth1_10">
+           <property name="geometry">
+            <rect>
              <x>560</x>
              <y>155</y>
              <width>20</width>

--- a/majiang.pro
+++ b/majiang.pro
@@ -1,0 +1,51 @@
+#-------------------------------------------------
+#
+# Project created by QtCreator
+#
+#-------------------------------------------------
+
+QT       += core gui
+QT += sql#使用数据库
+QT += multimedia#低层多媒体功能
+QT += network#添加网络
+
+greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+
+TARGET      = majiang
+TEMPLATE    = app
+MOC_DIR     = temp/moc
+RCC_DIR     = temp/rcc
+UI_DIR      = temp/ui
+OBJECTS_DIR = temp/obj
+#DESTDIR     = $$PWD/../bin
+
+SOURCES     += main.cpp \
+    inifile.cpp \
+    logindialog.cpp \
+    mainwidget.cpp \
+    majhong.cpp
+SOURCES     += iconhelper.cpp
+SOURCES     += appinit.cpp
+SOURCES     +=
+
+HEADERS     += iconhelper.h \
+    connnection.h \
+    inifile.h \
+    logindialog.h \
+    mainwidget.h \
+    majhong.h
+HEADERS     += appinit.h
+HEADERS     +=
+
+FORMS       += \
+    logindialog.ui \
+    mainwidget.ui
+
+RESOURCES   += main.qrc \
+    login.qrc
+
+RESOURCES   += qss.qrc
+CONFIG      += qt warn_off
+INCLUDEPATH += $$PWD
+
+DISTFILES +=

--- a/majiang.pro.user
+++ b/majiang.pro.user
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.14.0, 2021-07-10T10:21:05. -->
+<!-- Written by QtCreator 13.0.0, 2024-05-06T20:17:03. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
-  <value type="QByteArray">{a20f6ad6-334a-4ba7-9fd5-44aaf8e583a1}</value>
+  <value type="QByteArray">{175a3f36-086e-4adc-a2d3-b4ad23991ccd}</value>
  </data>
  <data>
   <variable>ProjectExplorer.Project.ActiveTarget</variable>
-  <value type="int">0</value>
+  <value type="qlonglong">0</value>
  </data>
  <data>
   <variable>ProjectExplorer.Project.EditorSettings</variable>
@@ -28,7 +28,7 @@
      <value type="QByteArray" key="CurrentPreferences">QmlJSGlobal</value>
     </valuemap>
    </valuemap>
-   <value type="int" key="EditorConfiguration.CodeStyle.Count">2</value>
+   <value type="qlonglong" key="EditorConfiguration.CodeStyle.Count">2</value>
    <value type="QByteArray" key="EditorConfiguration.Codec">UTF-8</value>
    <value type="bool" key="EditorConfiguration.ConstrainTooltips">false</value>
    <value type="int" key="EditorConfiguration.IndentSize">4</value>
@@ -37,14 +37,17 @@
    <value type="bool" key="EditorConfiguration.MouseHiding">true</value>
    <value type="bool" key="EditorConfiguration.MouseNavigation">true</value>
    <value type="int" key="EditorConfiguration.PaddingMode">1</value>
+   <value type="int" key="EditorConfiguration.PreferAfterWhitespaceComments">0</value>
+   <value type="bool" key="EditorConfiguration.PreferSingleLineComments">false</value>
    <value type="bool" key="EditorConfiguration.ScrollWheelZooming">true</value>
    <value type="bool" key="EditorConfiguration.ShowMargin">false</value>
-   <value type="int" key="EditorConfiguration.SmartBackspaceBehavior">0</value>
+   <value type="int" key="EditorConfiguration.SmartBackspaceBehavior">2</value>
    <value type="bool" key="EditorConfiguration.SmartSelectionChanging">true</value>
    <value type="bool" key="EditorConfiguration.SpacesForTabs">true</value>
    <value type="int" key="EditorConfiguration.TabKeyBehavior">0</value>
    <value type="int" key="EditorConfiguration.TabSize">8</value>
    <value type="bool" key="EditorConfiguration.UseGlobal">true</value>
+   <value type="bool" key="EditorConfiguration.UseIndenter">false</value>
    <value type="int" key="EditorConfiguration.Utf8BomBehavior">1</value>
    <value type="bool" key="EditorConfiguration.addFinalNewLine">true</value>
    <value type="bool" key="EditorConfiguration.cleanIndentation">true</value>
@@ -52,6 +55,7 @@
    <value type="QString" key="EditorConfiguration.ignoreFileTypes">*.md, *.MD, Makefile</value>
    <value type="bool" key="EditorConfiguration.inEntireDocument">false</value>
    <value type="bool" key="EditorConfiguration.skipTrailingWhitespace">true</value>
+   <value type="bool" key="EditorConfiguration.tintMarginArea">true</value>
   </valuemap>
  </data>
  <data>
@@ -59,6 +63,7 @@
   <valuemap type="QVariantMap">
    <valuemap type="QVariantMap" key="AutoTest.ActiveFrameworks">
     <value type="bool" key="AutoTest.Framework.Boost">true</value>
+    <value type="bool" key="AutoTest.Framework.CTest">false</value>
     <value type="bool" key="AutoTest.Framework.Catch">true</value>
     <value type="bool" key="AutoTest.Framework.GTest">true</value>
     <value type="bool" key="AutoTest.Framework.QtQuickTest">true</value>
@@ -67,14 +72,12 @@
    <valuemap type="QVariantMap" key="AutoTest.CheckStates"/>
    <value type="int" key="AutoTest.RunAfterBuild">0</value>
    <value type="bool" key="AutoTest.UseGlobal">true</value>
-   <valuelist type="QVariantList" key="ClangCodeModel.CustomCommandLineKey"/>
-   <value type="bool" key="ClangCodeModel.UseGlobalConfig">true</value>
-   <value type="QString" key="ClangCodeModel.WarningConfigId">Builtin.Questionable</value>
    <valuemap type="QVariantMap" key="ClangTools">
     <value type="bool" key="ClangTools.AnalyzeOpenFiles">true</value>
     <value type="bool" key="ClangTools.BuildBeforeAnalysis">true</value>
     <value type="QString" key="ClangTools.DiagnosticConfig">Builtin.DefaultTidyAndClazy</value>
-    <value type="int" key="ClangTools.ParallelJobs">4</value>
+    <value type="int" key="ClangTools.ParallelJobs">10</value>
+    <value type="bool" key="ClangTools.PreferConfigFile">true</value>
     <valuelist type="QVariantList" key="ClangTools.SelectedDirs"/>
     <valuelist type="QVariantList" key="ClangTools.SelectedFiles"/>
     <valuelist type="QVariantList" key="ClangTools.SuppressedDiagnostics"/>
@@ -86,21 +89,20 @@
   <variable>ProjectExplorer.Project.Target.0</variable>
   <valuemap type="QVariantMap">
    <value type="QString" key="DeviceType">Desktop</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Desktop Qt 5.15.2 clang 64bit</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Desktop Qt 5.15.2 clang 64bit</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">qt.qt5.5152.clang_64_kit</value>
-   <value type="int" key="ProjectExplorer.Target.ActiveBuildConfiguration">1</value>
-   <value type="int" key="ProjectExplorer.Target.ActiveDeployConfiguration">0</value>
-   <value type="int" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Desktop Qt 5.15.2 MinGW 64-bit</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Desktop Qt 5.15.2 MinGW 64-bit</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">qt.qt5.5152.win64_mingw81_kit</value>
+   <value type="qlonglong" key="ProjectExplorer.Target.ActiveBuildConfiguration">1</value>
+   <value type="qlonglong" key="ProjectExplorer.Target.ActiveDeployConfiguration">0</value>
+   <value type="qlonglong" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.0">
     <value type="int" key="EnableQmlDebugging">0</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/Users/mac/Qt/build-majiang-Desktop_Qt_5_15_2_clang_64bit-Debug</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/Users/mac/Qt/build-majiang-Desktop_Qt_5_15_2_clang_64bit-Debug</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">D:\mjhong-main\majiang\build\Desktop_Qt_5_15_2_MinGW_64_bit-Debug</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">D:/mjhong-main/majiang/build/Desktop_Qt_5_15_2_MinGW_64_bit-Debug</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QtProjectManager.QMakeBuildStep</value>
-      <value type="QString" key="QtProjectManager.QMakeBuildStep.QMakeArguments"></value>
       <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
       <valuelist type="QVariantList" key="QtProjectManager.QMakeBuildStep.SelectedAbis"/>
      </valuemap>
@@ -108,9 +110,9 @@
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
      </valuemap>
-     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build</value>
+     <value type="qlonglong" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">构建</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">构建</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
     </valuemap>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
@@ -119,28 +121,27 @@
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
       <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
      </valuemap>
-     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Clean</value>
+     <value type="qlonglong" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">清除</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">清除</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
     </valuemap>
     <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
     <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
     <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.CustomParsers"/>
+    <value type="bool" key="ProjectExplorer.BuildConfiguration.ParseStandardOutput">false</value>
     <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Debug</value>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4BuildConfiguration</value>
     <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">2</value>
-    <value type="int" key="RunSystemFunction">0</value>
    </valuemap>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.1">
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/Users/mac/Qt/build-majiang-Desktop_Qt_5_15_2_clang_64bit-Release</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/Users/mac/Qt/build-majiang-Desktop_Qt_5_15_2_clang_64bit-Release</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">D:\mjhong-main\majiang\build\Desktop_Qt_5_15_2_MinGW_64_bit-Release</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">D:/mjhong-main/majiang/build/Desktop_Qt_5_15_2_MinGW_64_bit-Release</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QtProjectManager.QMakeBuildStep</value>
-      <value type="QString" key="QtProjectManager.QMakeBuildStep.QMakeArguments"></value>
       <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
       <valuelist type="QVariantList" key="QtProjectManager.QMakeBuildStep.SelectedAbis"/>
      </valuemap>
@@ -148,9 +149,9 @@
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
      </valuemap>
-     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build</value>
+     <value type="qlonglong" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">构建</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">构建</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
     </valuemap>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
@@ -159,30 +160,29 @@
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
       <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
      </valuemap>
-     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Clean</value>
+     <value type="qlonglong" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">清除</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">清除</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
     </valuemap>
     <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
     <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
     <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.CustomParsers"/>
+    <value type="bool" key="ProjectExplorer.BuildConfiguration.ParseStandardOutput">false</value>
     <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Release</value>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4BuildConfiguration</value>
     <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">0</value>
     <value type="int" key="QtQuickCompiler">0</value>
-    <value type="int" key="RunSystemFunction">0</value>
    </valuemap>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.2">
     <value type="int" key="EnableQmlDebugging">0</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/Users/mac/Qt/build-majiang-Desktop_Qt_5_15_2_clang_64bit-Profile</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/Users/mac/Qt/build-majiang-Desktop_Qt_5_15_2_clang_64bit-Profile</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">D:\mjhong-main\majiang\build\Desktop_Qt_5_15_2_MinGW_64_bit-Profile</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">D:/mjhong-main/majiang/build/Desktop_Qt_5_15_2_MinGW_64_bit-Profile</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QtProjectManager.QMakeBuildStep</value>
-      <value type="QString" key="QtProjectManager.QMakeBuildStep.QMakeArguments"></value>
       <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
       <valuelist type="QVariantList" key="QtProjectManager.QMakeBuildStep.SelectedAbis"/>
      </valuemap>
@@ -190,9 +190,9 @@
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
      </valuemap>
-     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build</value>
+     <value type="qlonglong" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">构建</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">构建</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
     </valuemap>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
@@ -201,28 +201,28 @@
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
       <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
      </valuemap>
-     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Clean</value>
+     <value type="qlonglong" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">清除</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">清除</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
     </valuemap>
     <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
     <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
     <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.CustomParsers"/>
+    <value type="bool" key="ProjectExplorer.BuildConfiguration.ParseStandardOutput">false</value>
     <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Profile</value>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4BuildConfiguration</value>
     <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">0</value>
     <value type="int" key="QtQuickCompiler">0</value>
-    <value type="int" key="RunSystemFunction">0</value>
     <value type="int" key="SeparateDebugInfo">0</value>
    </valuemap>
-   <value type="int" key="ProjectExplorer.Target.BuildConfigurationCount">3</value>
+   <value type="qlonglong" key="ProjectExplorer.Target.BuildConfigurationCount">3</value>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.DeployConfiguration.0">
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
-     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">0</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Deploy</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Deploy</value>
+     <value type="qlonglong" key="ProjectExplorer.BuildStepList.StepsCount">0</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">部署</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">部署</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Deploy</value>
     </valuemap>
     <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">1</value>
@@ -230,348 +230,32 @@
     <value type="bool" key="ProjectExplorer.DeployConfiguration.CustomDataEnabled">false</value>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.DefaultDeployConfiguration</value>
    </valuemap>
-   <value type="int" key="ProjectExplorer.Target.DeployConfigurationCount">1</value>
+   <value type="qlonglong" key="ProjectExplorer.Target.DeployConfigurationCount">1</value>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.RunConfiguration.0">
-    <value type="QString" key="Analyzer.Perf.CallgraphMode">dwarf</value>
-    <valuelist type="QVariantList" key="Analyzer.Perf.Events">
-     <value type="QString">cpu-cycles</value>
-    </valuelist>
-    <valuelist type="QVariantList" key="Analyzer.Perf.ExtraArguments"/>
-    <value type="int" key="Analyzer.Perf.Frequency">250</value>
-    <valuelist type="QVariantList" key="Analyzer.Perf.RecordArguments">
-     <value type="QString">-e</value>
-     <value type="QString">cpu-cycles</value>
-     <value type="QString">--call-graph</value>
-     <value type="QString">dwarf,4096</value>
-     <value type="QString">-F</value>
-     <value type="QString">250</value>
-    </valuelist>
-    <value type="QString" key="Analyzer.Perf.SampleMode">-F</value>
     <value type="bool" key="Analyzer.Perf.Settings.UseGlobalSettings">true</value>
-    <value type="int" key="Analyzer.Perf.StackSize">4096</value>
-    <value type="bool" key="Analyzer.QmlProfiler.AggregateTraces">false</value>
-    <value type="bool" key="Analyzer.QmlProfiler.FlushEnabled">false</value>
-    <value type="uint" key="Analyzer.QmlProfiler.FlushInterval">1000</value>
-    <value type="QString" key="Analyzer.QmlProfiler.LastTraceFile"></value>
     <value type="bool" key="Analyzer.QmlProfiler.Settings.UseGlobalSettings">true</value>
-    <valuelist type="QVariantList" key="Analyzer.Valgrind.AddedSuppressionFiles"/>
-    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectBusEvents">false</value>
-    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectSystime">false</value>
-    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableBranchSim">false</value>
-    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableCacheSim">false</value>
-    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableEventToolTips">true</value>
-    <value type="double" key="Analyzer.Valgrind.Callgrind.MinimumCostRatio">0.01</value>
-    <value type="double" key="Analyzer.Valgrind.Callgrind.VisualisationMinimumCostRatio">10</value>
-    <value type="bool" key="Analyzer.Valgrind.FilterExternalIssues">true</value>
-    <value type="QString" key="Analyzer.Valgrind.KCachegrindExecutable">kcachegrind</value>
-    <value type="int" key="Analyzer.Valgrind.LeakCheckOnFinish">1</value>
-    <value type="int" key="Analyzer.Valgrind.NumCallers">25</value>
-    <valuelist type="QVariantList" key="Analyzer.Valgrind.RemovedSuppressionFiles"/>
-    <value type="int" key="Analyzer.Valgrind.SelfModifyingCodeDetection">1</value>
+    <value type="int" key="Analyzer.Valgrind.Callgrind.CostFormat">0</value>
     <value type="bool" key="Analyzer.Valgrind.Settings.UseGlobalSettings">true</value>
-    <value type="bool" key="Analyzer.Valgrind.ShowReachable">false</value>
-    <value type="bool" key="Analyzer.Valgrind.TrackOrigins">true</value>
-    <value type="QString" key="Analyzer.Valgrind.ValgrindExecutable">valgrind</value>
-    <valuelist type="QVariantList" key="Analyzer.Valgrind.VisibleErrorKinds">
-     <value type="int">0</value>
-     <value type="int">1</value>
-     <value type="int">2</value>
-     <value type="int">3</value>
-     <value type="int">4</value>
-     <value type="int">5</value>
-     <value type="int">6</value>
-     <value type="int">7</value>
-     <value type="int">8</value>
-     <value type="int">9</value>
-     <value type="int">10</value>
-     <value type="int">11</value>
-     <value type="int">12</value>
-     <value type="int">13</value>
-     <value type="int">14</value>
-    </valuelist>
     <valuelist type="QVariantList" key="CustomOutputParsers"/>
     <value type="int" key="PE.EnvironmentAspect.Base">2</value>
     <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/Users/mac/Qt/majiang/majiang.pro</value>
-    <value type="QString" key="ProjectExplorer.RunConfiguration.BuildKey">/Users/mac/Qt/majiang/majiang.pro</value>
-    <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>
+    <value type="bool" key="PE.EnvironmentAspect.PrintOnRun">false</value>
+    <value type="QString" key="PerfRecordArgsId">-e cpu-cycles --call-graph &quot;dwarf,4096&quot; -F 250</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:D:/mjhong-main/majiang/majiang.pro</value>
+    <value type="QString" key="ProjectExplorer.RunConfiguration.BuildKey">D:/mjhong-main/majiang/majiang.pro</value>
+    <value type="bool" key="ProjectExplorer.RunConfiguration.Customized">false</value>
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
     <value type="bool" key="RunConfiguration.UseLibrarySearchPath">true</value>
-    <value type="bool" key="RunConfiguration.UseQmlDebugger">false</value>
     <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
-    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/Users/mac/Qt/build-majiang-Desktop_Qt_5_15_2_clang_64bit-Release/majiang.app/Contents/MacOS</value>
+    <value type="QString" key="RunConfiguration.WorkingDirectory.default">D:/mjhong-main/majiang/build/Desktop_Qt_5_15_2_MinGW_64_bit-Release</value>
    </valuemap>
-   <value type="int" key="ProjectExplorer.Target.RunConfigurationCount">1</value>
-  </valuemap>
- </data>
- <data>
-  <variable>ProjectExplorer.Project.Target.1</variable>
-  <valuemap type="QVariantMap">
-   <value type="QString" key="DeviceType">Android.Device.Type</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Android Qt 5.15.2 Clang Multi-Abi</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Android Qt 5.15.2 Clang Multi-Abi</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">{ba22a8c7-4d4b-4725-ad47-9a274eff2038}</value>
-   <value type="int" key="ProjectExplorer.Target.ActiveBuildConfiguration">0</value>
-   <value type="int" key="ProjectExplorer.Target.ActiveDeployConfiguration">0</value>
-   <value type="int" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
-   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.0">
-    <value type="int" key="EnableQmlDebugging">0</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/Users/mac/Qt/build-majiang-Android_Qt_5_15_2_Clang_Multi_Abi-Debug</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/Users/mac/Qt/build-majiang-Android_Qt_5_15_2_Clang_Multi_Abi-Debug</value>
-    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
-     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
-      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QtProjectManager.QMakeBuildStep</value>
-      <value type="QString" key="QtProjectManager.QMakeBuildStep.QMakeArguments"></value>
-      <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
-      <valuelist type="QVariantList" key="QtProjectManager.QMakeBuildStep.SelectedAbis">
-       <value type="QString">armeabi-v7a</value>
-      </valuelist>
-     </valuemap>
-     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.1">
-      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
-     </valuemap>
-     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.2">
-      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Copy application data</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.AndroidPackageInstallationStep</value>
-     </valuemap>
-     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.3">
-      <value type="QString" key="BuildTargetSdk">android-30</value>
-      <value type="QString" key="KeystoreLocation"></value>
-      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build Android APK</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QmakeProjectManager.AndroidBuildApkStep</value>
-      <value type="bool" key="VerboseOutput">false</value>
-     </valuemap>
-     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">4</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
-    </valuemap>
-    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
-     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
-      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
-      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
-     </valuemap>
-     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Clean</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
-    </valuemap>
-    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
-    <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
-    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.CustomParsers"/>
-    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Debug</value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4BuildConfiguration</value>
-    <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">2</value>
-    <value type="int" key="RunSystemFunction">0</value>
-   </valuemap>
-   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.1">
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/Users/mac/Qt/build-majiang-Android_Qt_5_15_2_Clang_Multi_Abi-Release</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/Users/mac/Qt/build-majiang-Android_Qt_5_15_2_Clang_Multi_Abi-Release</value>
-    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
-     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
-      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QtProjectManager.QMakeBuildStep</value>
-      <value type="QString" key="QtProjectManager.QMakeBuildStep.QMakeArguments"></value>
-      <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
-      <valuelist type="QVariantList" key="QtProjectManager.QMakeBuildStep.SelectedAbis"/>
-     </valuemap>
-     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.1">
-      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
-     </valuemap>
-     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.2">
-      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Copy application data</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.AndroidPackageInstallationStep</value>
-     </valuemap>
-     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.3">
-      <value type="QString" key="BuildTargetSdk">android-30</value>
-      <value type="QString" key="KeystoreLocation"></value>
-      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build Android APK</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QmakeProjectManager.AndroidBuildApkStep</value>
-      <value type="bool" key="VerboseOutput">false</value>
-     </valuemap>
-     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">4</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
-    </valuemap>
-    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
-     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
-      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
-      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
-     </valuemap>
-     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Clean</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
-    </valuemap>
-    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
-    <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
-    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.CustomParsers"/>
-    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Release</value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4BuildConfiguration</value>
-    <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">0</value>
-    <value type="int" key="QtQuickCompiler">0</value>
-    <value type="int" key="RunSystemFunction">0</value>
-   </valuemap>
-   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.2">
-    <value type="int" key="EnableQmlDebugging">0</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/Users/mac/Qt/build-majiang-Android_Qt_5_15_2_Clang_Multi_Abi-Profile</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/Users/mac/Qt/build-majiang-Android_Qt_5_15_2_Clang_Multi_Abi-Profile</value>
-    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
-     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
-      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QtProjectManager.QMakeBuildStep</value>
-      <value type="QString" key="QtProjectManager.QMakeBuildStep.QMakeArguments"></value>
-      <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
-      <valuelist type="QVariantList" key="QtProjectManager.QMakeBuildStep.SelectedAbis"/>
-     </valuemap>
-     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.1">
-      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
-     </valuemap>
-     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.2">
-      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Copy application data</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.AndroidPackageInstallationStep</value>
-     </valuemap>
-     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.3">
-      <value type="QString" key="BuildTargetSdk">android-30</value>
-      <value type="QString" key="KeystoreLocation"></value>
-      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build Android APK</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QmakeProjectManager.AndroidBuildApkStep</value>
-      <value type="bool" key="VerboseOutput">false</value>
-     </valuemap>
-     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">4</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
-    </valuemap>
-    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
-     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
-      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
-      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
-     </valuemap>
-     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Clean</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
-    </valuemap>
-    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
-    <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
-    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.CustomParsers"/>
-    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Profile</value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4BuildConfiguration</value>
-    <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">0</value>
-    <value type="int" key="QtQuickCompiler">0</value>
-    <value type="int" key="RunSystemFunction">0</value>
-    <value type="int" key="SeparateDebugInfo">0</value>
-   </valuemap>
-   <value type="int" key="ProjectExplorer.Target.BuildConfigurationCount">3</value>
-   <valuemap type="QVariantMap" key="ProjectExplorer.Target.DeployConfiguration.0">
-    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
-     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
-      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.AndroidDeployQtStep</value>
-     </valuemap>
-     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Deploy</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Deploy</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Deploy</value>
-    </valuemap>
-    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">1</value>
-    <valuemap type="QVariantMap" key="ProjectExplorer.DeployConfiguration.CustomData"/>
-    <value type="bool" key="ProjectExplorer.DeployConfiguration.CustomDataEnabled">false</value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.AndroidDeployConfiguration2</value>
-   </valuemap>
-   <value type="int" key="ProjectExplorer.Target.DeployConfigurationCount">1</value>
-   <valuemap type="QVariantMap" key="ProjectExplorer.Target.RunConfiguration.0">
-    <value type="QString" key="Analyzer.Perf.CallgraphMode">dwarf</value>
-    <valuelist type="QVariantList" key="Analyzer.Perf.Events">
-     <value type="QString">cpu-cycles</value>
-    </valuelist>
-    <valuelist type="QVariantList" key="Analyzer.Perf.ExtraArguments"/>
-    <value type="int" key="Analyzer.Perf.Frequency">250</value>
-    <valuelist type="QVariantList" key="Analyzer.Perf.RecordArguments">
-     <value type="QString">-e</value>
-     <value type="QString">cpu-cycles</value>
-     <value type="QString">--call-graph</value>
-     <value type="QString">dwarf,4096</value>
-     <value type="QString">-F</value>
-     <value type="QString">250</value>
-    </valuelist>
-    <value type="QString" key="Analyzer.Perf.SampleMode">-F</value>
-    <value type="bool" key="Analyzer.Perf.Settings.UseGlobalSettings">true</value>
-    <value type="int" key="Analyzer.Perf.StackSize">4096</value>
-    <value type="bool" key="Analyzer.QmlProfiler.AggregateTraces">false</value>
-    <value type="bool" key="Analyzer.QmlProfiler.FlushEnabled">false</value>
-    <value type="uint" key="Analyzer.QmlProfiler.FlushInterval">1000</value>
-    <value type="QString" key="Analyzer.QmlProfiler.LastTraceFile"></value>
-    <value type="bool" key="Analyzer.QmlProfiler.Settings.UseGlobalSettings">true</value>
-    <valuelist type="QVariantList" key="Analyzer.Valgrind.AddedSuppressionFiles"/>
-    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectBusEvents">false</value>
-    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectSystime">false</value>
-    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableBranchSim">false</value>
-    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableCacheSim">false</value>
-    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableEventToolTips">true</value>
-    <value type="double" key="Analyzer.Valgrind.Callgrind.MinimumCostRatio">0.01</value>
-    <value type="double" key="Analyzer.Valgrind.Callgrind.VisualisationMinimumCostRatio">10</value>
-    <value type="bool" key="Analyzer.Valgrind.FilterExternalIssues">true</value>
-    <value type="QString" key="Analyzer.Valgrind.KCachegrindExecutable">kcachegrind</value>
-    <value type="int" key="Analyzer.Valgrind.LeakCheckOnFinish">1</value>
-    <value type="int" key="Analyzer.Valgrind.NumCallers">25</value>
-    <valuelist type="QVariantList" key="Analyzer.Valgrind.RemovedSuppressionFiles"/>
-    <value type="int" key="Analyzer.Valgrind.SelfModifyingCodeDetection">1</value>
-    <value type="bool" key="Analyzer.Valgrind.Settings.UseGlobalSettings">true</value>
-    <value type="bool" key="Analyzer.Valgrind.ShowReachable">false</value>
-    <value type="bool" key="Analyzer.Valgrind.TrackOrigins">true</value>
-    <value type="QString" key="Analyzer.Valgrind.ValgrindExecutable">valgrind</value>
-    <valuelist type="QVariantList" key="Analyzer.Valgrind.VisibleErrorKinds">
-     <value type="int">0</value>
-     <value type="int">1</value>
-     <value type="int">2</value>
-     <value type="int">3</value>
-     <value type="int">4</value>
-     <value type="int">5</value>
-     <value type="int">6</value>
-     <value type="int">7</value>
-     <value type="int">8</value>
-     <value type="int">9</value>
-     <value type="int">10</value>
-     <value type="int">11</value>
-     <value type="int">12</value>
-     <value type="int">13</value>
-     <value type="int">14</value>
-    </valuelist>
-    <valuelist type="QVariantList" key="CustomOutputParsers"/>
-    <value type="int" key="PE.EnvironmentAspect.Base">0</value>
-    <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.AndroidRunConfiguration:/Users/mac/Qt/majiang/majiang.pro</value>
-    <value type="QString" key="ProjectExplorer.RunConfiguration.BuildKey">/Users/mac/Qt/majiang/majiang.pro</value>
-    <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>
-    <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
-    <value type="bool" key="RunConfiguration.UseQmlDebugger">false</value>
-    <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
-   </valuemap>
-   <value type="int" key="ProjectExplorer.Target.RunConfigurationCount">1</value>
+   <value type="qlonglong" key="ProjectExplorer.Target.RunConfigurationCount">1</value>
   </valuemap>
  </data>
  <data>
   <variable>ProjectExplorer.Project.TargetCount</variable>
-  <value type="int">2</value>
+  <value type="qlonglong">1</value>
  </data>
  <data>
   <variable>ProjectExplorer.Project.Updater.FileVersion</variable>

--- a/majiang.pro.user.a20f6ad
+++ b/majiang.pro.user.a20f6ad
@@ -1,0 +1,584 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE QtCreatorProject>
+<!-- Written by QtCreator 4.14.0, 2021-07-10T10:21:05. -->
+<qtcreator>
+ <data>
+  <variable>EnvironmentId</variable>
+  <value type="QByteArray">{a20f6ad6-334a-4ba7-9fd5-44aaf8e583a1}</value>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.ActiveTarget</variable>
+  <value type="int">0</value>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.EditorSettings</variable>
+  <valuemap type="QVariantMap">
+   <value type="bool" key="EditorConfiguration.AutoIndent">true</value>
+   <value type="bool" key="EditorConfiguration.AutoSpacesForTabs">false</value>
+   <value type="bool" key="EditorConfiguration.CamelCaseNavigation">true</value>
+   <valuemap type="QVariantMap" key="EditorConfiguration.CodeStyle.0">
+    <value type="QString" key="language">Cpp</value>
+    <valuemap type="QVariantMap" key="value">
+     <value type="QByteArray" key="CurrentPreferences">CppGlobal</value>
+    </valuemap>
+   </valuemap>
+   <valuemap type="QVariantMap" key="EditorConfiguration.CodeStyle.1">
+    <value type="QString" key="language">QmlJS</value>
+    <valuemap type="QVariantMap" key="value">
+     <value type="QByteArray" key="CurrentPreferences">QmlJSGlobal</value>
+    </valuemap>
+   </valuemap>
+   <value type="int" key="EditorConfiguration.CodeStyle.Count">2</value>
+   <value type="QByteArray" key="EditorConfiguration.Codec">UTF-8</value>
+   <value type="bool" key="EditorConfiguration.ConstrainTooltips">false</value>
+   <value type="int" key="EditorConfiguration.IndentSize">4</value>
+   <value type="bool" key="EditorConfiguration.KeyboardTooltips">false</value>
+   <value type="int" key="EditorConfiguration.MarginColumn">80</value>
+   <value type="bool" key="EditorConfiguration.MouseHiding">true</value>
+   <value type="bool" key="EditorConfiguration.MouseNavigation">true</value>
+   <value type="int" key="EditorConfiguration.PaddingMode">1</value>
+   <value type="bool" key="EditorConfiguration.ScrollWheelZooming">true</value>
+   <value type="bool" key="EditorConfiguration.ShowMargin">false</value>
+   <value type="int" key="EditorConfiguration.SmartBackspaceBehavior">0</value>
+   <value type="bool" key="EditorConfiguration.SmartSelectionChanging">true</value>
+   <value type="bool" key="EditorConfiguration.SpacesForTabs">true</value>
+   <value type="int" key="EditorConfiguration.TabKeyBehavior">0</value>
+   <value type="int" key="EditorConfiguration.TabSize">8</value>
+   <value type="bool" key="EditorConfiguration.UseGlobal">true</value>
+   <value type="int" key="EditorConfiguration.Utf8BomBehavior">1</value>
+   <value type="bool" key="EditorConfiguration.addFinalNewLine">true</value>
+   <value type="bool" key="EditorConfiguration.cleanIndentation">true</value>
+   <value type="bool" key="EditorConfiguration.cleanWhitespace">true</value>
+   <value type="QString" key="EditorConfiguration.ignoreFileTypes">*.md, *.MD, Makefile</value>
+   <value type="bool" key="EditorConfiguration.inEntireDocument">false</value>
+   <value type="bool" key="EditorConfiguration.skipTrailingWhitespace">true</value>
+  </valuemap>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.PluginSettings</variable>
+  <valuemap type="QVariantMap">
+   <valuemap type="QVariantMap" key="AutoTest.ActiveFrameworks">
+    <value type="bool" key="AutoTest.Framework.Boost">true</value>
+    <value type="bool" key="AutoTest.Framework.Catch">true</value>
+    <value type="bool" key="AutoTest.Framework.GTest">true</value>
+    <value type="bool" key="AutoTest.Framework.QtQuickTest">true</value>
+    <value type="bool" key="AutoTest.Framework.QtTest">true</value>
+   </valuemap>
+   <valuemap type="QVariantMap" key="AutoTest.CheckStates"/>
+   <value type="int" key="AutoTest.RunAfterBuild">0</value>
+   <value type="bool" key="AutoTest.UseGlobal">true</value>
+   <valuelist type="QVariantList" key="ClangCodeModel.CustomCommandLineKey"/>
+   <value type="bool" key="ClangCodeModel.UseGlobalConfig">true</value>
+   <value type="QString" key="ClangCodeModel.WarningConfigId">Builtin.Questionable</value>
+   <valuemap type="QVariantMap" key="ClangTools">
+    <value type="bool" key="ClangTools.AnalyzeOpenFiles">true</value>
+    <value type="bool" key="ClangTools.BuildBeforeAnalysis">true</value>
+    <value type="QString" key="ClangTools.DiagnosticConfig">Builtin.DefaultTidyAndClazy</value>
+    <value type="int" key="ClangTools.ParallelJobs">4</value>
+    <valuelist type="QVariantList" key="ClangTools.SelectedDirs"/>
+    <valuelist type="QVariantList" key="ClangTools.SelectedFiles"/>
+    <valuelist type="QVariantList" key="ClangTools.SuppressedDiagnostics"/>
+    <value type="bool" key="ClangTools.UseGlobalSettings">true</value>
+   </valuemap>
+  </valuemap>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.Target.0</variable>
+  <valuemap type="QVariantMap">
+   <value type="QString" key="DeviceType">Desktop</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Desktop Qt 5.15.2 clang 64bit</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Desktop Qt 5.15.2 clang 64bit</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">qt.qt5.5152.clang_64_kit</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveBuildConfiguration">1</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveDeployConfiguration">0</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.0">
+    <value type="int" key="EnableQmlDebugging">0</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/Users/mac/Qt/build-majiang-Desktop_Qt_5_15_2_clang_64bit-Debug</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/Users/mac/Qt/build-majiang-Desktop_Qt_5_15_2_clang_64bit-Debug</value>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QtProjectManager.QMakeBuildStep</value>
+      <value type="QString" key="QtProjectManager.QMakeBuildStep.QMakeArguments"></value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
+      <valuelist type="QVariantList" key="QtProjectManager.QMakeBuildStep.SelectedAbis"/>
+     </valuemap>
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.1">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
+    </valuemap>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
+      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
+    <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.CustomParsers"/>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Debug</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4BuildConfiguration</value>
+    <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">2</value>
+    <value type="int" key="RunSystemFunction">0</value>
+   </valuemap>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.1">
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/Users/mac/Qt/build-majiang-Desktop_Qt_5_15_2_clang_64bit-Release</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/Users/mac/Qt/build-majiang-Desktop_Qt_5_15_2_clang_64bit-Release</value>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QtProjectManager.QMakeBuildStep</value>
+      <value type="QString" key="QtProjectManager.QMakeBuildStep.QMakeArguments"></value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
+      <valuelist type="QVariantList" key="QtProjectManager.QMakeBuildStep.SelectedAbis"/>
+     </valuemap>
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.1">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
+    </valuemap>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
+      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
+    <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.CustomParsers"/>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Release</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4BuildConfiguration</value>
+    <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">0</value>
+    <value type="int" key="QtQuickCompiler">0</value>
+    <value type="int" key="RunSystemFunction">0</value>
+   </valuemap>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.2">
+    <value type="int" key="EnableQmlDebugging">0</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/Users/mac/Qt/build-majiang-Desktop_Qt_5_15_2_clang_64bit-Profile</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/Users/mac/Qt/build-majiang-Desktop_Qt_5_15_2_clang_64bit-Profile</value>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QtProjectManager.QMakeBuildStep</value>
+      <value type="QString" key="QtProjectManager.QMakeBuildStep.QMakeArguments"></value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
+      <valuelist type="QVariantList" key="QtProjectManager.QMakeBuildStep.SelectedAbis"/>
+     </valuemap>
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.1">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
+    </valuemap>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
+      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
+    <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.CustomParsers"/>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Profile</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4BuildConfiguration</value>
+    <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">0</value>
+    <value type="int" key="QtQuickCompiler">0</value>
+    <value type="int" key="RunSystemFunction">0</value>
+    <value type="int" key="SeparateDebugInfo">0</value>
+   </valuemap>
+   <value type="int" key="ProjectExplorer.Target.BuildConfigurationCount">3</value>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.DeployConfiguration.0">
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">0</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Deploy</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Deploy</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Deploy</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">1</value>
+    <valuemap type="QVariantMap" key="ProjectExplorer.DeployConfiguration.CustomData"/>
+    <value type="bool" key="ProjectExplorer.DeployConfiguration.CustomDataEnabled">false</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.DefaultDeployConfiguration</value>
+   </valuemap>
+   <value type="int" key="ProjectExplorer.Target.DeployConfigurationCount">1</value>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.RunConfiguration.0">
+    <value type="QString" key="Analyzer.Perf.CallgraphMode">dwarf</value>
+    <valuelist type="QVariantList" key="Analyzer.Perf.Events">
+     <value type="QString">cpu-cycles</value>
+    </valuelist>
+    <valuelist type="QVariantList" key="Analyzer.Perf.ExtraArguments"/>
+    <value type="int" key="Analyzer.Perf.Frequency">250</value>
+    <valuelist type="QVariantList" key="Analyzer.Perf.RecordArguments">
+     <value type="QString">-e</value>
+     <value type="QString">cpu-cycles</value>
+     <value type="QString">--call-graph</value>
+     <value type="QString">dwarf,4096</value>
+     <value type="QString">-F</value>
+     <value type="QString">250</value>
+    </valuelist>
+    <value type="QString" key="Analyzer.Perf.SampleMode">-F</value>
+    <value type="bool" key="Analyzer.Perf.Settings.UseGlobalSettings">true</value>
+    <value type="int" key="Analyzer.Perf.StackSize">4096</value>
+    <value type="bool" key="Analyzer.QmlProfiler.AggregateTraces">false</value>
+    <value type="bool" key="Analyzer.QmlProfiler.FlushEnabled">false</value>
+    <value type="uint" key="Analyzer.QmlProfiler.FlushInterval">1000</value>
+    <value type="QString" key="Analyzer.QmlProfiler.LastTraceFile"></value>
+    <value type="bool" key="Analyzer.QmlProfiler.Settings.UseGlobalSettings">true</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.AddedSuppressionFiles"/>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectBusEvents">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectSystime">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableBranchSim">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableCacheSim">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableEventToolTips">true</value>
+    <value type="double" key="Analyzer.Valgrind.Callgrind.MinimumCostRatio">0.01</value>
+    <value type="double" key="Analyzer.Valgrind.Callgrind.VisualisationMinimumCostRatio">10</value>
+    <value type="bool" key="Analyzer.Valgrind.FilterExternalIssues">true</value>
+    <value type="QString" key="Analyzer.Valgrind.KCachegrindExecutable">kcachegrind</value>
+    <value type="int" key="Analyzer.Valgrind.LeakCheckOnFinish">1</value>
+    <value type="int" key="Analyzer.Valgrind.NumCallers">25</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.RemovedSuppressionFiles"/>
+    <value type="int" key="Analyzer.Valgrind.SelfModifyingCodeDetection">1</value>
+    <value type="bool" key="Analyzer.Valgrind.Settings.UseGlobalSettings">true</value>
+    <value type="bool" key="Analyzer.Valgrind.ShowReachable">false</value>
+    <value type="bool" key="Analyzer.Valgrind.TrackOrigins">true</value>
+    <value type="QString" key="Analyzer.Valgrind.ValgrindExecutable">valgrind</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.VisibleErrorKinds">
+     <value type="int">0</value>
+     <value type="int">1</value>
+     <value type="int">2</value>
+     <value type="int">3</value>
+     <value type="int">4</value>
+     <value type="int">5</value>
+     <value type="int">6</value>
+     <value type="int">7</value>
+     <value type="int">8</value>
+     <value type="int">9</value>
+     <value type="int">10</value>
+     <value type="int">11</value>
+     <value type="int">12</value>
+     <value type="int">13</value>
+     <value type="int">14</value>
+    </valuelist>
+    <valuelist type="QVariantList" key="CustomOutputParsers"/>
+    <value type="int" key="PE.EnvironmentAspect.Base">2</value>
+    <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/Users/mac/Qt/majiang/majiang.pro</value>
+    <value type="QString" key="ProjectExplorer.RunConfiguration.BuildKey">/Users/mac/Qt/majiang/majiang.pro</value>
+    <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>
+    <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
+    <value type="bool" key="RunConfiguration.UseLibrarySearchPath">true</value>
+    <value type="bool" key="RunConfiguration.UseQmlDebugger">false</value>
+    <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
+    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/Users/mac/Qt/build-majiang-Desktop_Qt_5_15_2_clang_64bit-Release/majiang.app/Contents/MacOS</value>
+   </valuemap>
+   <value type="int" key="ProjectExplorer.Target.RunConfigurationCount">1</value>
+  </valuemap>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.Target.1</variable>
+  <valuemap type="QVariantMap">
+   <value type="QString" key="DeviceType">Android.Device.Type</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Android Qt 5.15.2 Clang Multi-Abi</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Android Qt 5.15.2 Clang Multi-Abi</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">{ba22a8c7-4d4b-4725-ad47-9a274eff2038}</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveBuildConfiguration">0</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveDeployConfiguration">0</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.0">
+    <value type="int" key="EnableQmlDebugging">0</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/Users/mac/Qt/build-majiang-Android_Qt_5_15_2_Clang_Multi_Abi-Debug</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/Users/mac/Qt/build-majiang-Android_Qt_5_15_2_Clang_Multi_Abi-Debug</value>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QtProjectManager.QMakeBuildStep</value>
+      <value type="QString" key="QtProjectManager.QMakeBuildStep.QMakeArguments"></value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
+      <valuelist type="QVariantList" key="QtProjectManager.QMakeBuildStep.SelectedAbis">
+       <value type="QString">armeabi-v7a</value>
+      </valuelist>
+     </valuemap>
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.1">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
+     </valuemap>
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.2">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Copy application data</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.AndroidPackageInstallationStep</value>
+     </valuemap>
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.3">
+      <value type="QString" key="BuildTargetSdk">android-30</value>
+      <value type="QString" key="KeystoreLocation"></value>
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build Android APK</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QmakeProjectManager.AndroidBuildApkStep</value>
+      <value type="bool" key="VerboseOutput">false</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">4</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
+    </valuemap>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
+      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
+    <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.CustomParsers"/>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Debug</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4BuildConfiguration</value>
+    <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">2</value>
+    <value type="int" key="RunSystemFunction">0</value>
+   </valuemap>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.1">
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/Users/mac/Qt/build-majiang-Android_Qt_5_15_2_Clang_Multi_Abi-Release</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/Users/mac/Qt/build-majiang-Android_Qt_5_15_2_Clang_Multi_Abi-Release</value>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QtProjectManager.QMakeBuildStep</value>
+      <value type="QString" key="QtProjectManager.QMakeBuildStep.QMakeArguments"></value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
+      <valuelist type="QVariantList" key="QtProjectManager.QMakeBuildStep.SelectedAbis"/>
+     </valuemap>
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.1">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
+     </valuemap>
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.2">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Copy application data</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.AndroidPackageInstallationStep</value>
+     </valuemap>
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.3">
+      <value type="QString" key="BuildTargetSdk">android-30</value>
+      <value type="QString" key="KeystoreLocation"></value>
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build Android APK</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QmakeProjectManager.AndroidBuildApkStep</value>
+      <value type="bool" key="VerboseOutput">false</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">4</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
+    </valuemap>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
+      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
+    <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.CustomParsers"/>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Release</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4BuildConfiguration</value>
+    <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">0</value>
+    <value type="int" key="QtQuickCompiler">0</value>
+    <value type="int" key="RunSystemFunction">0</value>
+   </valuemap>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.2">
+    <value type="int" key="EnableQmlDebugging">0</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/Users/mac/Qt/build-majiang-Android_Qt_5_15_2_Clang_Multi_Abi-Profile</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/Users/mac/Qt/build-majiang-Android_Qt_5_15_2_Clang_Multi_Abi-Profile</value>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QtProjectManager.QMakeBuildStep</value>
+      <value type="QString" key="QtProjectManager.QMakeBuildStep.QMakeArguments"></value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
+      <valuelist type="QVariantList" key="QtProjectManager.QMakeBuildStep.SelectedAbis"/>
+     </valuemap>
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.1">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
+     </valuemap>
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.2">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Copy application data</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.AndroidPackageInstallationStep</value>
+     </valuemap>
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.3">
+      <value type="QString" key="BuildTargetSdk">android-30</value>
+      <value type="QString" key="KeystoreLocation"></value>
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build Android APK</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QmakeProjectManager.AndroidBuildApkStep</value>
+      <value type="bool" key="VerboseOutput">false</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">4</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
+    </valuemap>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
+      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
+    <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.CustomParsers"/>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Profile</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4BuildConfiguration</value>
+    <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">0</value>
+    <value type="int" key="QtQuickCompiler">0</value>
+    <value type="int" key="RunSystemFunction">0</value>
+    <value type="int" key="SeparateDebugInfo">0</value>
+   </valuemap>
+   <value type="int" key="ProjectExplorer.Target.BuildConfigurationCount">3</value>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.DeployConfiguration.0">
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.AndroidDeployQtStep</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Deploy</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Deploy</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Deploy</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">1</value>
+    <valuemap type="QVariantMap" key="ProjectExplorer.DeployConfiguration.CustomData"/>
+    <value type="bool" key="ProjectExplorer.DeployConfiguration.CustomDataEnabled">false</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.AndroidDeployConfiguration2</value>
+   </valuemap>
+   <value type="int" key="ProjectExplorer.Target.DeployConfigurationCount">1</value>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.RunConfiguration.0">
+    <value type="QString" key="Analyzer.Perf.CallgraphMode">dwarf</value>
+    <valuelist type="QVariantList" key="Analyzer.Perf.Events">
+     <value type="QString">cpu-cycles</value>
+    </valuelist>
+    <valuelist type="QVariantList" key="Analyzer.Perf.ExtraArguments"/>
+    <value type="int" key="Analyzer.Perf.Frequency">250</value>
+    <valuelist type="QVariantList" key="Analyzer.Perf.RecordArguments">
+     <value type="QString">-e</value>
+     <value type="QString">cpu-cycles</value>
+     <value type="QString">--call-graph</value>
+     <value type="QString">dwarf,4096</value>
+     <value type="QString">-F</value>
+     <value type="QString">250</value>
+    </valuelist>
+    <value type="QString" key="Analyzer.Perf.SampleMode">-F</value>
+    <value type="bool" key="Analyzer.Perf.Settings.UseGlobalSettings">true</value>
+    <value type="int" key="Analyzer.Perf.StackSize">4096</value>
+    <value type="bool" key="Analyzer.QmlProfiler.AggregateTraces">false</value>
+    <value type="bool" key="Analyzer.QmlProfiler.FlushEnabled">false</value>
+    <value type="uint" key="Analyzer.QmlProfiler.FlushInterval">1000</value>
+    <value type="QString" key="Analyzer.QmlProfiler.LastTraceFile"></value>
+    <value type="bool" key="Analyzer.QmlProfiler.Settings.UseGlobalSettings">true</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.AddedSuppressionFiles"/>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectBusEvents">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectSystime">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableBranchSim">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableCacheSim">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableEventToolTips">true</value>
+    <value type="double" key="Analyzer.Valgrind.Callgrind.MinimumCostRatio">0.01</value>
+    <value type="double" key="Analyzer.Valgrind.Callgrind.VisualisationMinimumCostRatio">10</value>
+    <value type="bool" key="Analyzer.Valgrind.FilterExternalIssues">true</value>
+    <value type="QString" key="Analyzer.Valgrind.KCachegrindExecutable">kcachegrind</value>
+    <value type="int" key="Analyzer.Valgrind.LeakCheckOnFinish">1</value>
+    <value type="int" key="Analyzer.Valgrind.NumCallers">25</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.RemovedSuppressionFiles"/>
+    <value type="int" key="Analyzer.Valgrind.SelfModifyingCodeDetection">1</value>
+    <value type="bool" key="Analyzer.Valgrind.Settings.UseGlobalSettings">true</value>
+    <value type="bool" key="Analyzer.Valgrind.ShowReachable">false</value>
+    <value type="bool" key="Analyzer.Valgrind.TrackOrigins">true</value>
+    <value type="QString" key="Analyzer.Valgrind.ValgrindExecutable">valgrind</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.VisibleErrorKinds">
+     <value type="int">0</value>
+     <value type="int">1</value>
+     <value type="int">2</value>
+     <value type="int">3</value>
+     <value type="int">4</value>
+     <value type="int">5</value>
+     <value type="int">6</value>
+     <value type="int">7</value>
+     <value type="int">8</value>
+     <value type="int">9</value>
+     <value type="int">10</value>
+     <value type="int">11</value>
+     <value type="int">12</value>
+     <value type="int">13</value>
+     <value type="int">14</value>
+    </valuelist>
+    <valuelist type="QVariantList" key="CustomOutputParsers"/>
+    <value type="int" key="PE.EnvironmentAspect.Base">0</value>
+    <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.AndroidRunConfiguration:/Users/mac/Qt/majiang/majiang.pro</value>
+    <value type="QString" key="ProjectExplorer.RunConfiguration.BuildKey">/Users/mac/Qt/majiang/majiang.pro</value>
+    <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>
+    <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
+    <value type="bool" key="RunConfiguration.UseQmlDebugger">false</value>
+    <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
+   </valuemap>
+   <value type="int" key="ProjectExplorer.Target.RunConfigurationCount">1</value>
+  </valuemap>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.TargetCount</variable>
+  <value type="int">2</value>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.Updater.FileVersion</variable>
+  <value type="int">22</value>
+ </data>
+ <data>
+  <variable>Version</variable>
+  <value type="int">22</value>
+ </data>
+</qtcreator>


### PR DESCRIPTION
4.全部为麻将游戏的前端代码的改进
4.1新增选庄界面。
4.2新增多种箭头，方框，提示从牌堆中拿到的牌，提示不可胡牌的类型，提示不需要的一门等。
4.3增加自定义系统的所有按钮（在设置界面中），玩家可以自由选择麻将游戏方法包括：牌数（108或136），庄家（定庄还是随机选庄），花牌（自选花牌，不显示花牌，花牌可碰，预测牌不显示等），打牌（是否吃，是否明杠，是否暗杠，是否吃三方，是否报听等），财神（具有30可选方式）。所有按钮点击打钩选择。
